### PR TITLE
Mb catch theta2 error

### DIFF
--- a/dev/cnv_using_subwf_test.cwl
+++ b/dev/cnv_using_subwf_test.cwl
@@ -1,0 +1,206 @@
+cwlVersion: v1.0
+class: Workflow
+id: cnv_using_subwf_test
+requirements:
+  - class: ScatterFeatureRequirement
+  - class: MultipleInputFeatureRequirement
+  - class: SubworkflowFeatureRequirement
+inputs:
+  indexed_reference_fasta: {type: File, secondaryFiles: [.fai, ^.dict]}
+  reference_fai: File
+  reference_dict: File
+  input_tumor_aligned:
+    type: File
+    secondaryFiles: |
+      ${
+        var dpath = self.location.replace(self.basename, "")
+        if(self.nameext == '.bam'){
+          return {"location": dpath+self.nameroot+".bai", "class": "File"}
+        }
+        else{
+          return {"location": dpath+self.basename+".crai", "class": "File"}
+        }
+      }
+    doc: "tumor BAM or CRAM"
+
+  input_tumor_name: string
+  input_normal_aligned:
+    type: File
+    secondaryFiles: |
+      ${
+        var dpath = self.location.replace(self.basename, "")
+        if(self.nameext == '.bam'){
+          return {"location": dpath+self.nameroot+".bai", "class": "File"}
+        }
+        else{
+          return {"location": dpath+self.basename+".crai", "class": "File"}
+        }
+      }
+    doc: "normal BAM or CRAM"
+
+  input_normal_name: string
+  wgs_calling_interval_list: {type: File, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
+  cfree_threads: {type: ['null', int], doc: "For ControlFreeC.  Recommend 16 max, as I/O gets saturated after that losing any advantage.", default: 16}
+  cfree_chr_len: {type: File, doc: "file with chromosome lengths"}
+  cfree_ploidy: {type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try"}
+  cfree_mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
+  cfree_mate_orientation_control: {type: ['null', {type: enum, name: mate_orientation_control, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
+  b_allele: {type: ['null', File], secondaryFiles: ['.tbi'],  doc: "germline calls, needed for BAF.  GATK HC VQSR input recommended.  Tool will prefilter for germline and pass if expression given"}
+  cnvkit_annotation_file: {type: File, doc: "refFlat.txt file"}
+  cnvkit_wgs_mode: {type: ['null', string], doc: "for WGS mode, input Y. leave blank for hybrid mode", default: "Y"}
+  cfree_coeff_var: {type: ['null', float], default: 0.05, doc: "Coefficient of variation to set window size.  Default 0.05 recommended"}
+  cfree_contamination_adjustment: {type: ['null', boolean], doc: "TRUE or FALSE to have ControlFreec estimate normal contam"}
+  combined_include_expression: {type: ['null', string], doc: "Filter expression if vcf has non-PASS combined calls, use as-needed, i.e. for VarDict: FILTER=\"PASS\" && (INFO/STATUS=\"Germline\" | INFO/STATUS=\"StrongSomatic\")"}
+  combined_exclude_expression: {type: ['null', string], doc: "Filter expression if vcf has non-PASS combined calls, use as-needed"}  
+  min_theta2_frac: {type: ['null', float], doc: "Minimum fraction of genome with copy umber alterations.  Default is 0.05, recommend 0.01", default: 0.01}
+  cfree_sex: {type: ['null', {type: enum, name: sex, symbols: ["XX", "XY"] }], doc: "If known, XX for female, XY for male"}
+  cnvkit_sex: {type: ['null', string ], doc: "If known, choices are m,y,male,Male,f,x,female,Female"}
+  output_basename: string
+  vardict_min_vaf: {type: ['null', float], doc: "Min variant allele frequency for vardict to consider.  Recommend 0.05", default: 0.05}
+  select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
+  vardict_cpus: {type: ['null', int], default: 9}
+  vardict_ram: {type: ['null', int], default: 18, doc: "In GB"}
+  vardict_padding: {type: ['null', int], doc: "Padding to add to input intervals, recommened 0 if intervals already padded, 150 if not", default: 150}
+  vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
+
+
+outputs:
+  ctrlfreec_pval: {type: File, outputSource: run_controlfreec/ctrlfreec_pval}
+  ctrlfreec_config: {type: File, outputSource: run_controlfreec/ctrlfreec_config}
+  ctrlfreec_pngs: {type: 'File[]', outputSource: run_controlfreec/ctrlfreec_pngs}
+  ctrlfreec_bam_ratio: {type: File, outputSource: run_controlfreec/ctrlfreec_bam_ratio}
+  ctrlfreec_bam_seg: {type: File, outputSource: run_controlfreec/ctrlfreec_bam_seg}
+  ctrlfreec_baf: {type: File, outputSource: run_controlfreec/ctrlfreec_baf}
+  ctrlfreec_info: {type: File, outputSource: run_controlfreec/ctrlfreec_info}
+  cnvkit_cnr: {type: File, outputSource: run_cnvkit/cnvkit_cnr}
+  cnvkit_cnn_output: {type: ['null', File], outputSource: run_cnvkit/cnvkit_cnn_output}
+  cnvkit_calls: {type: File, outputSource: run_cnvkit/cnvkit_calls}
+  cnvkit_metrics: {type: File, outputSource: run_cnvkit/cnvkit_metrics}
+  cnvkit_gainloss: {type: File, outputSource: run_cnvkit/cnvkit_gainloss}
+  cnvkit_seg: {type: File, outputSource: run_cnvkit/cnvkit_seg}
+  theta2_calls: {type: File?, outputSource: run_theta2_purity/theta2_adjusted_cns}
+  theta2_seg: {type: File?, outputSource: run_theta2_purity/theta2_adjusted_seg}
+  theta2_subclonal_results: {type: ['null', 'File[]'], outputSource: run_theta2_purity/theta2_subclonal_results}
+  theta2_subclonal_cns: {type: ['null', 'File[]'], outputSource: run_theta2_purity/theta2_subclonal_cns}
+  theta2_subclone_seg: {type: ['null', 'File[]'], outputSource: run_theta2_purity/theta2_subclone_seg}
+  vardict_vep_somatic_only_vcf: {type: File, outputSource: run_vardict/vardict_vep_somatic_only_vcf}
+  vardict_vep_somatic_only_tbi: {type: File, outputSource: run_vardict/vardict_vep_somatic_only_tbi}
+  vardict_vep_somatic_only_maf: {type: File, outputSource: run_vardict/vardict_vep_somatic_only_maf}
+  vardict_prepass_vcf: {type: File, outputSource: run_vardict/vardict_prepass_vcf}
+
+
+steps:
+  python_vardict_interval_split:
+    run: ../tools/python_vardict_interval_split.cwl
+    doc: "Custom interval list generation for vardict input. Briefly, ~60M bp per interval list, 20K bp intervals, lists break on chr and N reginos only"
+    in:
+      wgs_bed_file: wgs_calling_interval_list
+    out: [split_intervals_bed]
+
+  gatk_filter_germline:
+    run: ../tools/gatk_filter_germline_variant.cwl
+    in:
+      input_vcf: b_allele
+      reference_fasta: indexed_reference_fasta
+      output_basename: output_basename
+    out:
+      [filtered_vcf, filtered_pass_vcf]
+
+  samtools_cram2bam_plus_calmd_tumor:
+    run: ../tools/samtools_cram2bam_plus_calmd.cwl
+    in:
+      input_reads: input_tumor_aligned
+      threads:
+        valueFrom: ${return 16;}
+      reference: indexed_reference_fasta
+    out: [bam_file]
+
+  samtools_cram2bam_plus_calmd_normal:
+    run: ../tools/samtools_cram2bam_plus_calmd.cwl
+    in:
+      input_reads: input_normal_aligned
+      threads:
+        valueFrom: ${return 16;}
+      reference: indexed_reference_fasta
+    out: [bam_file]
+
+  run_vardict:
+    run: ../sub_workflows/kfdrc_vardict_sub_wf.cwl
+    in:
+      indexed_reference_fasta: indexed_reference_fasta
+      input_tumor_aligned: samtools_cram2bam_plus_calmd_tumor/bam_file
+      input_tumor_name: input_tumor_name
+      input_normal_aligned: samtools_cram2bam_plus_calmd_normal/bam_file
+      input_normal_name: input_normal_name
+      output_basename: output_basename
+      reference_dict: reference_dict
+      bed_invtl_split: python_vardict_interval_split/split_intervals_bed
+      padding: vardict_padding
+      min_vaf: vardict_min_vaf
+      select_vars_mode: select_vars_mode
+      cpus: vardict_cpus
+      ram: vardict_ram
+      vep_cache: vep_cache
+    out:
+      [vardict_vep_somatic_only_vcf, vardict_vep_somatic_only_tbi, vardict_vep_somatic_only_maf, vardict_prepass_vcf]
+
+
+  run_controlfreec:
+    run: ../sub_workflows/kfdrc_controlfreec_sub_wf.cwl
+    in:
+      input_tumor_aligned: samtools_cram2bam_plus_calmd_tumor/bam_file
+      input_tumor_name: input_tumor_name
+      input_normal_aligned: samtools_cram2bam_plus_calmd_normal/bam_file
+      threads: cfree_threads
+      output_basename: output_basename
+      ploidy: cfree_ploidy
+      mate_orientation_sample: cfree_mate_orientation_sample
+      mate_orientation_control: cfree_mate_orientation_control
+      indexed_reference_fasta: indexed_reference_fasta
+      reference_fai: reference_fai
+      b_allele: gatk_filter_germline/filtered_pass_vcf
+      chr_len: cfree_chr_len
+      coeff_var: cfree_coeff_var
+      contamination_adjustment: cfree_contamination_adjustment
+      cfree_sex: cfree_sex
+    out:
+      [ctrlfreec_pval, ctrlfreec_config, ctrlfreec_pngs, ctrlfreec_bam_ratio, ctrlfreec_bam_seg, ctrlfreec_baf, ctrlfreec_info]
+
+  run_cnvkit:
+    run: ../sub_workflows/kfdrc_cnvkit_sub_wf.cwl
+    in:
+      input_tumor_aligned: samtools_cram2bam_plus_calmd_tumor/bam_file
+      tumor_sample_name: input_tumor_name
+      input_normal_aligned: samtools_cram2bam_plus_calmd_normal/bam_file
+      reference: indexed_reference_fasta
+      normal_sample_name: input_normal_name
+      wgs_mode: cnvkit_wgs_mode
+      b_allele_vcf: gatk_filter_germline/filtered_pass_vcf
+      annotation_file: cnvkit_annotation_file
+      output_basename: output_basename
+      sex: cnvkit_sex
+    out:
+      [cnvkit_cnr, cnvkit_cnn_output, cnvkit_calls, cnvkit_metrics, cnvkit_gainloss, cnvkit_seg]
+
+  run_theta2_purity:
+    run: ../sub_workflows/kfdrc_run_theta2_sub_wf.cwl
+    in:
+      tumor_cns: run_cnvkit/cnvkit_calls
+      reference_cnn: run_cnvkit/cnvkit_cnn_output
+      tumor_sample_name: input_tumor_name
+      normal_sample_name: input_normal_name
+      paired_vcf: run_vardict/vardict_prepass_vcf
+      combined_include_expression: combined_include_expression
+      combined_exclude_expression: combined_exclude_expression
+      min_theta2_frac: min_theta2_frac
+      output_basename: output_basename
+    out:
+      [theta2_adjusted_cns, theta2_adjusted_seg, theta2_subclonal_results, theta2_subclonal_cns, theta2_subclone_seg]
+
+$namespaces:
+  sbg: https://sevenbridges.com
+hints:
+  - class: 'sbg:maxNumberOfParallelInstances'
+    value: 4
+  - class: 'sbg:AWSInstanceType'
+    value: c5.9xlarge

--- a/sub_workflows/kfdrc_run_theta2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_run_theta2_sub_wf.cwl
@@ -19,11 +19,11 @@ inputs:
   output_basename: string
 
 outputs:
-  theta2_adjusted_cns: {type: File, outputSource: cnvkit_import_theta2/theta2_adjusted_cns}
-  theta2_adjusted_seg: {type: File, outputSource: cnvkit_import_theta2/theta2_adjusted_seg}
-  theta2_subclonal_results: {type: 'File[]', outputSource: [run_theta2/n3_graph, run_theta2/n2_results, run_theta2/best_results]}
-  theta2_subclonal_cns: {type: 'File[]', outputSource: cnvkit_import_theta2/theta2_subclone_cns}
-  theta2_subclone_seg: {type: 'File[]', outputSource: cnvkit_import_theta2/theta2_subclone_seg}
+  theta2_adjusted_cns: {type: File?, outputSource: cnvkit_import_theta2/theta2_adjusted_cns}
+  theta2_adjusted_seg: {type: File?, outputSource: cnvkit_import_theta2/theta2_adjusted_seg}
+  theta2_subclonal_results: {type: ['null', 'File[]'], outputSource: [run_theta2/n3_graph, run_theta2/n2_results, run_theta2/best_results]}
+  theta2_subclonal_cns: {type: ['null', 'File[]'], outputSource: cnvkit_import_theta2/theta2_subclone_cns}
+  theta2_subclone_seg: {type: ['null', 'File[]'], outputSource: cnvkit_import_theta2/theta2_subclone_seg}
 
 steps:
   bcftools_filter_combined_vcf:

--- a/tools/cnvkit_import_theta2.cwl
+++ b/tools/cnvkit_import_theta2.cwl
@@ -22,7 +22,7 @@ arguments:
       }
 
       cnvkit.py import-theta
-      ${if (inputs.tumor_cns != null) {return inputs.tumor_cns.path;}}
+      $(inputs.tumor_cns)
       ${if (inputs.theta2_n2_results != null) {return inputs.theta2_n2_results.path;}}
       -d ./
 
@@ -35,7 +35,7 @@ arguments:
       rm ${return inputs.tumor_sample_name}.cns
 
       cnvkit.py import-theta
-      ${if (inputs.tumor_cns != null) {return inputs.tumor_cns.path;}}
+      $(inputs.tumor_cns)
       ${if (inputs.theta2_best_results != null) {return inputs.theta2_best_results.path;}}
       -d ./
 

--- a/tools/cnvkit_import_theta2.cwl
+++ b/tools/cnvkit_import_theta2.cwl
@@ -22,38 +22,38 @@ arguments:
       }
 
       cnvkit.py import-theta
-      $(inputs.tumor_cns.path)
-      $(inputs.theta2_n2_results.path)
+      ${if (inputs.tumor_cns != null) {return inputs.tumor_cns.path;}}
+      ${if (inputs.theta2_n2_results != null) {return inputs.theta2_n2_results.path;}}
       -d ./
 
-      mv $(inputs.output_basename).call-1.cns $(inputs.output_basename).theta2.total.cns
+      mv ${return inputs.output_basename}.call-1.cns ${return inputs.output_basename}.theta2.total.cns
       
-      ln -s $(inputs.output_basename).theta2.total.cns $(inputs.tumor_sample_name).cns
+      ln -s ${return inputs.output_basename}.theta2.total.cns ${return inputs.tumor_sample_name}.cns
 
-      cnvkit.py export seg $(inputs.tumor_sample_name).cns -o $(inputs.output_basename).theta2.total.seg
+      cnvkit.py export seg ${return inputs.tumor_sample_name}.cns -o ${return inputs.output_basename}.theta2.total.seg
 
-      rm $(inputs.tumor_sample_name).cns
+      rm ${return inputs.tumor_sample_name}.cns
 
       cnvkit.py import-theta
-      $(inputs.tumor_cns.path)
-      $(inputs.theta2_best_results.path)
+      ${if (inputs.tumor_cns != null) {return inputs.tumor_cns.path;}}
+      ${if (inputs.theta2_best_results != null) {return inputs.theta2_best_results.path;}}
       -d ./
 
-      mv $(inputs.output_basename).call-1.cns $(inputs.output_basename).theta2.subclone1.cns
+      mv ${return inputs.output_basename}.call-1.cns ${return inputs.output_basename}.theta2.subclone1.cns
 
-      ln -s $(inputs.output_basename).theta2.subclone1.cns $(inputs.tumor_sample_name).cns
+      ln -s ${return inputs.output_basename}.theta2.subclone1.cns ${return inputs.tumor_sample_name}.cns
 
-      cnvkit.py export seg $(inputs.tumor_sample_name).cns -o $(inputs.output_basename).theta2.subclone1.seg
+      cnvkit.py export seg ${return inputs.tumor_sample_name}.cns -o ${return inputs.output_basename}.theta2.subclone1.seg
 
-      rm $(inputs.tumor_sample_name).cns
+      rm ${return inputs.tumor_sample_name}.cns
 
-      SC2=$(inputs.output_basename).call-2.cns;
+      SC2=${return inputs.output_basename}.call-2.cns;
 
       if [ -f "$SC2" ]; then
-          mv $(inputs.output_basename).call-2.cns $(inputs.output_basename).theta2.subclone2.cns;
-          ln -s $(inputs.output_basename).theta2.subclone2.cns $(inputs.tumor_sample_name).cns;
-          cnvkit.py export seg $(inputs.tumor_sample_name).cns -o $(inputs.output_basename).theta2.subclone2.seg;
-          rm $(inputs.tumor_sample_name).cns;
+          mv ${return inputs.output_basename}.call-2.cns ${return inputs.output_basename}.theta2.subclone2.cns;
+          ln -s ${return inputs.output_basename}.theta2.subclone2.cns ${return inputs.tumor_sample_name}.cns;
+          cnvkit.py export seg ${return inputs.tumor_sample_name}.cns -o ${return inputs.output_basename}.theta2.subclone2.seg;
+          rm ${return inputs.tumor_sample_name}.cns;
       else
         echo "second subclone file not found.  skipping! >&2;";
       fi

--- a/tools/cnvkit_import_theta2.cwl
+++ b/tools/cnvkit_import_theta2.cwl
@@ -10,11 +10,18 @@ requirements:
     ramMin: 8000
     coresMin: 4
 
-baseCommand: [cnvkit.py, import-theta]  
+baseCommand: []  
 arguments:
   - position: 1
     shellQuote: false
     valueFrom: >- 
+      ${
+        if (inputs.theta2_n2_results == null){
+          return "echo Theta 2 input is null, skipping purity adjustment >&2; exit 0;"
+        }
+      }
+
+      cnvkit.py import-theta
       $(inputs.tumor_cns.path)
       $(inputs.theta2_n2_results.path)
       -d ./
@@ -48,7 +55,7 @@ arguments:
           cnvkit.py export seg $(inputs.tumor_sample_name).cns -o $(inputs.output_basename).theta2.subclone2.seg;
           rm $(inputs.tumor_sample_name).cns;
       else
-        echo "second subclone file not found.  skipping!";
+        echo "second subclone file not found.  skipping! >&2;";
       fi
 
 inputs:
@@ -60,19 +67,19 @@ inputs:
 
 outputs:
   theta2_adjusted_cns:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.theta2.total.cns'
   theta2_adjusted_seg:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.theta2.total.seg'
   theta2_subclone_cns:
-    type: File[]
+    type: ['null', 'File[]']
     outputBinding:
       glob: '*.theta2.subclone*.cns'
   theta2_subclone_seg:
-    type: File[]
+    type: ['null', 'File[]']
     outputBinding:
       glob: '*.theta2.subclone*.seg'
     

--- a/tools/cnvkit_import_theta2.cwl
+++ b/tools/cnvkit_import_theta2.cwl
@@ -22,7 +22,7 @@ arguments:
       }
 
       cnvkit.py import-theta
-      $(inputs.tumor_cns)
+      $(inputs.tumor_cns.path)
       ${if (inputs.theta2_n2_results != null) {return inputs.theta2_n2_results.path;}}
       -d ./
 
@@ -35,7 +35,7 @@ arguments:
       rm ${return inputs.tumor_sample_name}.cns
 
       cnvkit.py import-theta
-      $(inputs.tumor_cns)
+      $(inputs.tumor_cns.path)
       ${if (inputs.theta2_best_results != null) {return inputs.theta2_best_results.path;}}
       -d ./
 

--- a/tools/cnvkit_import_theta2.cwl
+++ b/tools/cnvkit_import_theta2.cwl
@@ -55,15 +55,15 @@ arguments:
           cnvkit.py export seg ${return inputs.tumor_sample_name}.cns -o ${return inputs.output_basename}.theta2.subclone2.seg;
           rm ${return inputs.tumor_sample_name}.cns;
       else
-        echo "second subclone file not found.  skipping! >&2;";
+        echo "second subclone file not found. Skipping!" >&2;
       fi
 
 inputs:
   tumor_cns: File
   tumor_sample_name: string
   output_basename: string
-  theta2_best_results: File
-  theta2_n2_results: File
+  theta2_best_results: File?
+  theta2_n2_results: File?
 
 outputs:
   theta2_adjusted_cns:

--- a/tools/theta2_purity.cwl
+++ b/tools/theta2_purity.cwl
@@ -10,11 +10,14 @@ requirements:
     ramMin: 32000
     coresMin: 8
 
-baseCommand: [/THetA/bin/RunTHetA]
+baseCommand: ["/bin/bash", "-c"]
 arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
+      set -eo pipefail
+
+      /THetA/bin/RunTHetA
       --TUMOR_FILE $(inputs.tumor_snp.path)
       --NORMAL_FILE $(inputs.normal_snp.path)
       --OUTPUT_PREFIX $(inputs.output_basename)
@@ -22,7 +25,7 @@ arguments:
       --MIN_FRAC $(inputs.min_frac)
       $(inputs.interval_count.path)
       ||
-      echo "Theta2 failed, likely due to insufficient copy number variation to calculate purity, or due to an input error, skipping >&2;"
+      (echo "Theta2 failed, likely due to insufficient copy number variation to calculate purity, or due to an input error, skipping >&2"; exit 0;)
 inputs:
   tumor_snp: File
   normal_snp: File

--- a/tools/theta2_purity.cwl
+++ b/tools/theta2_purity.cwl
@@ -21,38 +21,40 @@ arguments:
       --NUM_PROCESSES 8
       --MIN_FRAC $(inputs.min_frac)
       $(inputs.interval_count.path)
+      ||
+      echo "Theta2 failed, likely due to insufficient copy number variation to calculate purity, or due to an input error, skipping >&2;"
 inputs:
   tumor_snp: File
   normal_snp: File
   interval_count: File
   output_basename: string
-  min_frac: {type: ['null', float], doc: "Minimum fraction of genome with copy umber alterations.  Default is 0.05", default: 0.05}
+  min_frac: {type: ['null', float], doc: "Minimum fraction of genome with copy number alterations.  Default is 0.05", default: 0.05}
 outputs:
   n2_graph:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.n2.graph.pdf'
   n2_results:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.n2.results'
   n2_withBounds:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.n2.withBounds'
   n3_graph:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.n3.graph.pdf'
   n3_results:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.n3.results'
   n3_withBounds:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.n3.withBounds'
   best_results:
-    type: File
+    type: File?
     outputBinding:
       glob: '*.BEST.results'

--- a/workflow/kfdrc_cnvkit_plus_theta2.cwl
+++ b/workflow/kfdrc_cnvkit_plus_theta2.cwl
@@ -33,11 +33,11 @@ outputs:
   cnvkit_metrics: {type: File, outputSource: cnvkit/output_metrics}
   cnvkit_gainloss: {type: File, outputSource: cnvkit/output_gainloss}
   cnvkit_seg: {type: File, outputSource: cnvkit/output_seg}
-  theta2_calls: {type: File, outputSource: cnvkit_import_theta2/theta2_adjusted_cns}
-  theta2_seg: {type: File, outputSource: cnvkit_import_theta2/theta2_adjusted_seg}
-  theta2_subclonal_results: {type: 'File[]', outputSource: [run_theta2/n3_graph, run_theta2/n2_results, run_theta2/best_results]}
-  theta2_subclonal_cns: {type: 'File[]', outputSource: cnvkit_import_theta2/theta2_subclone_cns}
-  theta2_subclone_seg: {type: 'File[]', outputSource: cnvkit_import_theta2/theta2_subclone_seg}
+  theta2_calls: {type: File?, outputSource: cnvkit_import_theta2/theta2_adjusted_cns}
+  theta2_seg: {type: File?, outputSource: cnvkit_import_theta2/theta2_adjusted_seg}
+  theta2_subclonal_results: {type: ['null', 'File[]'], outputSource: [run_theta2/n3_graph, run_theta2/n2_results, run_theta2/best_results]}
+  theta2_subclonal_cns: {type: ['null', 'File[]'], outputSource: cnvkit_import_theta2/theta2_subclone_cns}
+  theta2_subclone_seg: {type: ['null', 'File[]'], outputSource: cnvkit_import_theta2/theta2_subclone_seg}
 
 steps:
   gatk_filter_germline:

--- a/workflow/kfdrc_combined_somatic_wgs_cnv_wf.cwl
+++ b/workflow/kfdrc_combined_somatic_wgs_cnv_wf.cwl
@@ -72,11 +72,11 @@ outputs:
   cnvkit_metrics: {type: File, outputSource: cnvkit/output_metrics}
   cnvkit_gainloss: {type: File, outputSource: cnvkit/output_gainloss}
   cnvkit_seg: {type: File, outputSource: cnvkit/output_seg}
-  theta2_calls: {type: File, outputSource: cnvkit_import_theta2/theta2_adjusted_cns}
-  theta2_seg: {type: File, outputSource: cnvkit_import_theta2/theta2_adjusted_seg}
-  theta2_subclonal_results: {type: 'File[]', outputSource: [run_theta2/n3_graph, run_theta2/n2_results, run_theta2/best_results]}
-  theta2_subclonal_cns: {type: 'File[]', outputSource: cnvkit_import_theta2/theta2_subclone_cns}
-  theta2_subclone_seg: {type: 'File[]', outputSource: cnvkit_import_theta2/theta2_subclone_seg}
+  theta2_calls: {type: File?, outputSource: cnvkit_import_theta2/theta2_adjusted_cns}
+  theta2_seg: {type: File?, outputSource: cnvkit_import_theta2/theta2_adjusted_seg}
+  theta2_subclonal_results: {type: ['null', 'File[]'], outputSource: [run_theta2/n3_graph, run_theta2/n2_results, run_theta2/best_results]}
+  theta2_subclonal_cns: {type: ['null', 'File[]'], outputSource: cnvkit_import_theta2/theta2_subclone_cns}
+  theta2_subclone_seg: {type: ['null', 'File[]'], outputSource: cnvkit_import_theta2/theta2_subclone_seg}
 
 steps:
   samtools_tumor_cram2bam:

--- a/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
+++ b/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
@@ -84,11 +84,11 @@ outputs:
   cnvkit_metrics: {type: File, outputSource: run_cnvkit/cnvkit_metrics}
   cnvkit_gainloss: {type: File, outputSource: run_cnvkit/cnvkit_gainloss}
   cnvkit_seg: {type: File, outputSource: run_cnvkit/cnvkit_seg}
-  theta2_calls: {type: File, outputSource: run_theta2_purity/theta2_adjusted_cns}
-  theta2_seg: {type: File, outputSource: run_theta2_purity/theta2_adjusted_seg}
-  theta2_subclonal_results: {type: 'File[]', outputSource: run_theta2_purity/theta2_subclonal_results}
-  theta2_subclonal_cns: {type: 'File[]', outputSource: run_theta2_purity/theta2_subclonal_cns}
-  theta2_subclone_seg: {type: 'File[]', outputSource: run_theta2_purity/theta2_subclone_seg}
+  theta2_calls: {type: File?, outputSource: run_theta2_purity/theta2_adjusted_cns}
+  theta2_seg: {type: File?, outputSource: run_theta2_purity/theta2_adjusted_seg}
+  theta2_subclonal_results: {type: ['null', 'File[]'], outputSource: run_theta2_purity/theta2_subclonal_results}
+  theta2_subclonal_cns: {type: ['null', 'File[]'], outputSource: run_theta2_purity/theta2_subclonal_cns}
+  theta2_subclone_seg: {type: ['null', 'File[]'], outputSource: run_theta2_purity/theta2_subclone_seg}
   strelka2_vep_vcf: {type: File, outputSource: run_strelka2/strelka2_vep_vcf}
   strelka2_vep_tbi: {type: File, outputSource: run_strelka2/strelka2_vep_tbi}
   strelka2_prepass_vcf: {type: File, outputSource: run_strelka2/strelka2_prepass_vcf}


### PR DESCRIPTION
Solves issue when Theta2 fails, the whole WF is tanked.  Instead, it will just have null outputs as cnvkit outputs without theta2 adjustments are still valid.  See ticket: https://app.zenhub.com/workspaces/d3b-bfx-5cdd720eed0dce4209e0b8a5/issues/kids-first/kf-genomics-harmonization/466