### PR TITLE
:racehorse: added old instance hints for mutect2, vardict, and lancet…

### DIFF
--- a/workflow/kfdrc_production_WES_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_WES_somatic_variant_cnv_wf.cwl
@@ -158,6 +158,9 @@ steps:
     out: [bam_file]
 
   run_vardict:
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     run: ../sub_workflows/kfdrc_vardict_sub_wf.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta
@@ -178,6 +181,9 @@ steps:
       [vardict_vep_somatic_only_vcf, vardict_vep_somatic_only_tbi, vardict_vep_somatic_only_maf, vardict_prepass_vcf]
 
   run_lancet:
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     run: ../sub_workflows/kfdrc_lancet_sub_wf.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta
@@ -235,6 +241,9 @@ steps:
       [cnvkit_cnr, cnvkit_cnn_output, cnvkit_calls, cnvkit_metrics, cnvkit_gainloss, cnvkit_seg]
 
   run_mutect2:
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     run: ../sub_workflows/kfdrc_mutect2_sub_wf.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta

--- a/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
+++ b/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
@@ -157,6 +157,9 @@ steps:
     out: [bam_file]
 
   run_vardict:
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     run: ../sub_workflows/kfdrc_vardict_sub_wf.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta
@@ -229,6 +232,9 @@ steps:
       [theta2_adjusted_cns, theta2_adjusted_seg, theta2_subclonal_results, theta2_subclonal_cns, theta2_subclone_seg]
 
   run_mutect2:
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     run: ../sub_workflows/kfdrc_mutect2_sub_wf.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta
@@ -289,6 +295,9 @@ steps:
     out: [output]
 
   run_lancet:
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     run: ../sub_workflows/kfdrc_lancet_sub_wf.cwl
     in:
       indexed_reference_fasta: indexed_reference_fasta


### PR DESCRIPTION
… to improve run time.  Before we had instance hints to turn running 3 of the callers as if they were on a mini-hpc for better parallization. that got lost in the code refactor.  adding that back in