### PR TITLE
:hammer: added ability to specify VEP reference version

### DIFF
--- a/sub_workflows/kfdrc_lancet_sub_wf.cwl
+++ b/sub_workflows/kfdrc_lancet_sub_wf.cwl
@@ -18,6 +18,7 @@ inputs:
   ram: {type: ['null', int], default: 12, doc: "Adjust in rare circumstances in which 12 GB is not enough."}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   window: {type: int, doc: "window size for lancet.  default is 600, recommend 500 for WGS, 600 for exome+"}
   padding: {type: int, doc: "If WGS (less likely), default 25, if exome+, recommend half window size"}
 
@@ -75,6 +76,7 @@ steps:
         valueFrom: ${return "lancet_somatic"}
       reference: indexed_reference_fasta
       cache: vep_cache
+      ref_build: vep_ref_build
     out: [output_vcf, output_tbi, output_maf, warn_txt]
 
 $namespaces:

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -44,6 +44,7 @@ inputs:
   input_normal_name: string
   exome_flag: {type: ['null', string], doc: "set to 'Y' for exome mode"}
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   output_basename: string
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
@@ -135,6 +136,7 @@ steps:
         valueFrom: ${return "mutect2_somatic"}
       reference: indexed_reference_fasta
       cache: vep_cache
+      ref_build: vep_ref_build
     out: [output_vcf, output_tbi, output_maf, warn_txt]
 
 $namespaces:

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -40,6 +40,7 @@ inputs:
   input_normal_name: string
   exome_flag: {type: ['null', string], doc: "set to 'Y' for exome mode"}
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   output_basename: string
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
@@ -101,4 +102,5 @@ steps:
         valueFrom: ${return "strelka2_somatic"}
       reference: indexed_reference_fasta
       cache: vep_cache
+      ref_build: vep_ref_build
     out: [output_vcf, output_tbi, output_maf, warn_txt]

--- a/sub_workflows/kfdrc_vardict_sub_wf.cwl
+++ b/sub_workflows/kfdrc_vardict_sub_wf.cwl
@@ -20,6 +20,7 @@ inputs:
   cpus: {type: ['null', int], default: 9}
   ram: {type: ['null', int], default: 18, doc: "In GB"}
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
 
 outputs:
   vardict_vep_somatic_only_vcf: {type: File, outputSource: vep_annot_vardict/output_vcf}
@@ -86,6 +87,7 @@ steps:
         valueFrom: ${return "vardict_somatic"}
       reference: indexed_reference_fasta
       cache: vep_cache
+      ref_build: vep_ref_build
     out: [output_vcf, output_tbi, output_maf, warn_txt]
 
 $namespaces:

--- a/workflow/kfdrc_production_WES_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_WES_somatic_variant_cnv_wf.cwl
@@ -49,6 +49,7 @@ inputs:
   lancet_padding: {type: ['null', int], doc: "Recommend 0 if interval file padded already, half window size if not", default: 0}
   vardict_padding: {type: ['null', int], doc: "Padding to add to input intervals, recommend 0 if intervals already padded, 150 if not", default: 0}
   vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   padded_capture_regions: {type: ['null', File], doc: "Recommend 100bp pad, for somatic variant"}
   unpadded_capture_regions: {type: ['null', File], doc: "Capture regions with NO padding for cnv calling"}
   cfree_chr_len: {type: File, doc: "file with chromosome lengths"}
@@ -177,6 +178,7 @@ steps:
       cpus: vardict_cpus
       ram: vardict_ram
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
     out:
       [vardict_vep_somatic_only_vcf, vardict_vep_somatic_only_tbi, vardict_vep_somatic_only_maf, vardict_prepass_vcf]
 
@@ -199,6 +201,7 @@ steps:
       window: lancet_window
       padding: lancet_padding
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
     out:
       [lancet_vep_vcf, lancet_vep_tbi, lancet_vep_maf, lancet_prepass_vcf]
 
@@ -258,6 +261,7 @@ steps:
       exome_flag:
         valueFrom: ${return "Y";}
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:
@@ -276,6 +280,7 @@ steps:
       exome_flag:
         valueFrom: ${return "Y";}
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:

--- a/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
+++ b/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
@@ -51,6 +51,7 @@ inputs:
   lancet_padding: {type: ['null', int], doc: "Recommend 0 if interval file padded already, half window size if not", default: 300}
   vardict_padding: {type: ['null', int], doc: "Padding to add to input intervals, recommened 0 if intervals already padded, 150 if not", default: 150}
   vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   cfree_chr_len: {type: File, doc: "file with chromosome lengths"}
   cfree_ploidy: {type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try"}
   cfree_mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
@@ -176,6 +177,7 @@ steps:
       cpus: vardict_cpus
       ram: vardict_ram
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
     out:
       [vardict_vep_somatic_only_vcf, vardict_vep_somatic_only_tbi, vardict_vep_somatic_only_maf, vardict_prepass_vcf]
 
@@ -249,6 +251,7 @@ steps:
       exome_flag:
         valueFrom: ${return "N";}
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:
@@ -267,6 +270,7 @@ steps:
       exome_flag:
         valueFrom: ${return "N";}
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:
@@ -313,6 +317,7 @@ steps:
       window: lancet_window
       padding: lancet_padding
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
     out:
       [lancet_vep_vcf, lancet_vep_tbi, lancet_vep_maf, lancet_prepass_vcf]
 


### PR DESCRIPTION
Based on a feature request from our Australian collaborators, allow to specify ref version for VEP step. Tested on hg37 SBG test files for [WGS](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/f829f182-1f61-43aa-9710-0e10d7c446f7/) and [WES](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/636a84ac-ff68-438d-bc1c-a6c96efdc2f8/).