### PR TITLE
Mb open vep ref port

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Somatic variant and SV call results are annoated using Variant Effect Predictor,
 
 ### Recent updates
 
+As of March 9, 2020, the input for setting VEP reference version has been added.
+Also, the input bed var name for strelka2 has been renamed for better accuracy.
+
 As of February 24, 2020, this workflow has been updated to make b allele (germline call) input file for copy number truly optional.
 Also, some [GATK-recommended](https://gatkforums.broadinstitute.org/gatk/discussion/2806/howto-apply-hard-filters-to-a-call-set) filters are applied to input file, plus a min DP 10 requirement, when given
 A brief description of what this file is and a way to generate it is found in the Tips to Run section.
@@ -62,14 +65,15 @@ You can use the `include_expression` `Filter="PASS"` to achieve this.
     - `wgs_calling_interval_list`: [wgs_calling_regions.hg38.interval_list](https://console.cloud.google.com/storage/browser/genomics-public-data/resources/broad/hg38/v0?pli=1) - need a valid google account, this is a link to the resource bundle from Broad GATK.*To create our 'wgs_canonical_calling_regions.hg38.interval_list', edit this file* by leaving only entries related to chr 1-22, X,Y, and M.M may need to be added.
     - `af_only_gnomad_vcf`: [af-only-gnomad.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/-gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
     - `exac_common_vcf`: [small_exac_common_3.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
-    - `hg38_strelka_bed`: [hg38_strelka.bed.gz'](https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md#extended-use-cases) - this link here has the bed-formatted text needed to copy to create this file. You will need to bgzip this file.
-     - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
-     Current production workflow uses this version, and is compatible with the release used in the vcf2maf tool.
-     - `threads`: 16
-     - `chr_len`: hs38_chr.len, this a tsv file with chromosomes and their lengths.
+    - `strelka2_bed`: [hg38_strelka.bed.gz'](https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md#extended-use-cases) - this link here has the bed-formatted text needed to copy to create this file. You will need to bgzip this file.
+    - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
+    - `vep_ref_build`: `GRCh38` - reference version of `vep_cache`
+    Current production workflow uses this version, and is compatible with the release used in the vcf2maf tool.
+    - `threads`: 16
+    - `chr_len`: hs38_chr.len, this a tsv file with chromosomes and their lengths.
       The first column must be chromosomes, optionally the secnod can be an alternate format of chromosomes.
       Last column must be chromosome length.
-      Using the `hg38_strelka_bed`, and removing chrM can be a good source for this.
+      Using the `strelka2_bed`, and removing chrM can be a good source for this.
     - `coeff_var`: 0.05
     - `contamination_adjustment`: FALSE
 

--- a/sub_workflows/kfdrc_manta_sub_wf.cwl
+++ b/sub_workflows/kfdrc_manta_sub_wf.cwl
@@ -9,7 +9,7 @@ requirements:
 inputs:
   indexed_reference_fasta: {type: File, secondaryFiles: [.fai, ^.dict]}
   reference_dict: File
-  hg38_strelka_bed: {type: File, secondaryFiles: ['.tbi']}
+  strelka2_bed: {type: File, secondaryFiles: ['.tbi']}
   input_tumor_aligned:
     type: File
     secondaryFiles: |
@@ -54,7 +54,7 @@ steps:
       input_normal_cram: input_normal_aligned
       output_basename: output_basename
       reference: indexed_reference_fasta
-      hg38_strelka_bed: hg38_strelka_bed
+      strelka2_bed: strelka2_bed
     out: [output_sv]
 
   rename_manta_samples:

--- a/sub_workflows/kfdrc_mutect2_filter_support_subwf.cwl
+++ b/sub_workflows/kfdrc_mutect2_filter_support_subwf.cwl
@@ -64,6 +64,7 @@ steps:
     in:
       aligned_reads: input_tumor_aligned
       reference: indexed_reference_fasta
+      reference_dict: reference_dict
       interval_list: wgs_calling_interval_list
       exac_common_vcf: exac_common_vcf
     scatter: [interval_list]
@@ -76,6 +77,7 @@ steps:
     in:
       aligned_reads: input_normal_aligned
       reference: indexed_reference_fasta
+      reference_dict: reference_dict
       interval_list: wgs_calling_interval_list
       exac_common_vcf: exac_common_vcf
     scatter: [interval_list]

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -44,6 +44,7 @@ inputs:
   input_normal_name: string
   exome_flag: {type: ['null', string], doc: "set to 'Y' for exome mode"}
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   output_basename: string
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
@@ -137,6 +138,7 @@ steps:
         valueFrom: ${return "mutect2_somatic"}
       reference: indexed_reference_fasta
       cache: vep_cache
+      ref_build: vep_ref_build
     out: [output_vcf, output_tbi, output_maf, warn_txt]
 
 $namespaces:

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -40,6 +40,7 @@ inputs:
   input_normal_name: string
   exome_flag: {type: ['null', string], doc: "set to 'Y' for exome mode"}
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   output_basename: string
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
@@ -101,4 +102,5 @@ steps:
         valueFrom: ${return "strelka2_somatic"}
       reference: indexed_reference_fasta
       cache: vep_cache
+      ref_build: vep_ref_build
     out: [output_vcf, output_tbi, output_maf, warn_txt]

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -9,7 +9,7 @@ requirements:
 inputs:
   indexed_reference_fasta: {type: File, secondaryFiles: [.fai, ^.dict]}
   reference_dict: File
-  hg38_strelka_bed: {type: File, secondaryFiles: ['.tbi']}
+  strelka2_bed: {type: File, secondaryFiles: ['.tbi']}
   input_tumor_aligned:
     type: File
     secondaryFiles: |
@@ -57,7 +57,7 @@ steps:
       input_tumor_aligned: input_tumor_aligned
       input_normal_aligned: input_normal_aligned
       reference: indexed_reference_fasta
-      hg38_strelka_bed: hg38_strelka_bed
+      strelka2_bed: strelka2_bed
       exome_flag: exome_flag
     out: [output_snv, output_indel]
 

--- a/tools/gatk_filtermutectcalls.cwl
+++ b/tools/gatk_filtermutectcalls.cwl
@@ -37,6 +37,7 @@ inputs:
   mutect_vcf: {type: File, secondaryFiles: [.tbi]}
   mutect_stats: File
   reference: File
+  reference_dict: File
   output_basename: string
   contamination_table: File
   segmentation_table: File

--- a/tools/gatk_getpileupsummaries.cwl
+++ b/tools/gatk_getpileupsummaries.cwl
@@ -33,6 +33,7 @@ arguments:
 inputs:
   aligned_reads: {type: File, secondaryFiles: ['.crai']}
   reference: File
+  reference_dict: File
   interval_list: File
   exac_common_vcf: {type: File, secondaryFiles: [.tbi]}
 

--- a/tools/index_references.cwl
+++ b/tools/index_references.cwl
@@ -35,7 +35,7 @@ inputs:
   input_fasta_file: File
   af_only_gnomad_vcf: File
   exac_common_vcf: File
-  hg38_strelka_bed: File
+  strelka2_bed: File
 
 outputs:
   indexed_reference_fasta:
@@ -57,7 +57,7 @@ outputs:
     outputBinding:
       glob: '$(inputs.exac_common_vcf.basename)'
     secondaryFiles: [.tbi]
-  indexed_hg38_strelka_bed:
+  indexed_strelka2_bed:
     type: File
     outputBinding:
       glob: '$(inputs.hg38_strelka_bed.basename)'

--- a/tools/index_references.cwl
+++ b/tools/index_references.cwl
@@ -27,9 +27,9 @@ arguments:
 
       tabix $(inputs.exac_common_vcf.basename)
 
-      cp $(inputs.hg38_strelka_bed.path) .
+      cp $(inputs.strelka2_bed.path) .
 
-      tabix $(inputs.hg38_strelka_bed.basename)
+      tabix $(inputs.strelka2_bed.basename)
 
 inputs:
   input_fasta_file: File
@@ -60,5 +60,5 @@ outputs:
   indexed_strelka2_bed:
     type: File
     outputBinding:
-      glob: '$(inputs.hg38_strelka_bed.basename)'
+      glob: '$(inputs.strelka2_bed.basename)'
     secondaryFiles: [.tbi]

--- a/tools/manta.cwl
+++ b/tools/manta.cwl
@@ -36,7 +36,7 @@ arguments:
 
 inputs:
     reference: {type: File, secondaryFiles: [.fai]}
-    hg38_strelka_bed: {type: File, secondaryFiles: [.tbi]}
+    strelka2_bed: {type: File, secondaryFiles: [.tbi]}
     input_tumor_cram: {type: ["null", File], secondaryFiles: [.crai]}
     input_normal_cram: {type: ["null", File], secondaryFiles: [.crai]}
     output_basename: string

--- a/tools/manta.cwl
+++ b/tools/manta.cwl
@@ -18,7 +18,7 @@ arguments:
     shellQuote: false
     valueFrom: >-
       ${
-        var std = " --ref " + inputs.reference.path + " --callRegions " + inputs.hg38_strelka_bed.path + " --runDir=./ && ./runWorkflow.py -m local -j 36 --quiet ";
+        var std = " --ref " + inputs.reference.path + " --callRegions " + inputs.strelka2_bed.path + " --runDir=./ && ./runWorkflow.py -m local -j 36 --quiet ";
         var mv = " && mv results/variants/";
         if (typeof inputs.input_tumor_cram === 'undefined' || inputs.input_tumor_cram === null){
           var mv_cmd = mv + "diploidSV.vcf.gz " +  inputs.output_basename + ".manta.diploidSV.vcf.gz" + mv + "diploidSV.vcf.gz.tbi " + inputs.output_basename + ".manta.diploidSV.vcf.gz.tbi";

--- a/tools/strelka2.cwl
+++ b/tools/strelka2.cwl
@@ -18,7 +18,7 @@ arguments:
       --normalBam $(inputs.input_normal_aligned.path)
       --tumorBam $(inputs.input_tumor_aligned.path)
       --ref $(inputs.reference.path)
-      --callRegions $(inputs.hg38_strelka_bed.path)
+      --callRegions $(inputs.strelka2_bed.path)
       ${
         var arg = "--runDir=./";
         if (inputs.exome_flag == 'Y'){

--- a/tools/strelka2.cwl
+++ b/tools/strelka2.cwl
@@ -31,7 +31,7 @@ arguments:
 
 inputs:
   reference: {type: File, secondaryFiles: [.fai]}
-  hg38_strelka_bed: { type: File, secondaryFiles: [.tbi], label: gzipped bed file }
+  strelka2_bed: { type: File, secondaryFiles: [.tbi], label: gzipped bed file }
   exome_flag: { type: ['null', string], doc: "Y if exome/capture, defaults to WGS"}
   input_tumor_aligned:
     type: File

--- a/workflow/kfdrc_somatic_caller_workflow.cwl
+++ b/workflow/kfdrc_somatic_caller_workflow.cwl
@@ -11,6 +11,8 @@ doc: >-
   Somatic variant and SV call results are annoated using Variant Effect Predictor, with the Memorial Sloane Kettering Cancer Center (MSKCC) vcf2maf wrapper.
   
   ### Recent updates
+  As of March 9, 2020, the input for setting VEP reference version has been added.
+  Also, the input bed var name for strelka2 has been renamed for better accuracy
   
   As of February 24, 2020, this workflow has been updated to make b allele (germline call) input file for copy number truly optional.
   Also, some [GATK-recommended](https://gatkforums.broadinstitute.org/gatk/discussion/2806/howto-apply-hard-filters-to-a-call-set) filters are applied to input file, plus a min DP 10 requirement, when given
@@ -69,7 +71,7 @@ doc: >-
   
     - exac_common_vcf: small_exac_common_3.hg38.vcf.gz # Broad GATK exac reference file
   
-    - hg38_strelka_bed: hg38_strelka.bed.gz # bgzipped chromosome bed file, chr 1-22, X, Y ,M
+    - strelka2_bed: hg38_strelka.bed.gz # bgzipped chromosome bed file, chr 1-22, X, Y ,M
   
     - threads: 16
   
@@ -80,8 +82,10 @@ doc: >-
     - contamination_adjustment: FALSE
   
     - vep_cache: homo_sapiens_vep_93_GRCh38_convert_cache.tar.gz # tar gzipped cache from ensembl/local converted cache
+
+    - vep_ref_build: GRCh38 # reference build that vep_cache is based on
   
-   - include_expression: `Filter="PASS"`
+    - include_expression: `Filter="PASS"`
 
   ### Links/Resources:
   
@@ -102,7 +106,7 @@ inputs:
   wgs_calling_interval_list: {type: File, doc: "GATK interval calling list", sbg:suggestedValue: {class: 'File', path: '5d9e3424e4b0950cce15fe6e', name: 'wgs_canonical_calling_regions.hg38.interval_list'}}
   af_only_gnomad_vcf: {type: File, doc: "Broad GATK gnomad reference file", sbg:suggestedValue: {class: 'File', path: '5d9e3424e4b0950cce15fe70', name: 'af-only-gnomad.hg38.vcf.gz'}}
   exac_common_vcf: {type: File, doc: "Broad GATK exac reference file", sbg:suggestedValue: {class: 'File', path: '5d9e3424e4b0950cce15fe72', name: 'small_exac_common_3.hg38.vcf.gz'}}
-  hg38_strelka_bed: {type: File, doc: "bgzipped chromosome bed file", sbg:suggestedValue: {class: 'File', path: '5d9e3424e4b0950cce15fe6d', name: 'hg38_strelka.bed.gz'}}
+  strelka2_bed: {type: File, doc: "bgzipped chromosome bed file", sbg:suggestedValue: {class: 'File', path: '5d9e3424e4b0950cce15fe6d', name: 'hg38_strelka.bed.gz'}}
   input_tumor_aligned:
     type: File
     secondaryFiles: |
@@ -176,9 +180,9 @@ steps:
       input_fasta_file: reference_fasta
       af_only_gnomad_vcf: af_only_gnomad_vcf
       exac_common_vcf: exac_common_vcf
-      hg38_strelka_bed: hg38_strelka_bed
+      strelka2_bed: strelka2_bed
     out:
-      [indexed_reference_fasta, indexed_af_only_gnomad_vcf, indexed_exac_common_vcf, indexed_hg38_strelka_bed, reference_fai]
+      [indexed_reference_fasta, indexed_af_only_gnomad_vcf, indexed_exac_common_vcf, indexed_strelka2_bed, reference_fai]
 
   gatk_filter_germline:
     run: ../tools/gatk_filter_germline_variant.cwl
@@ -245,7 +249,7 @@ steps:
     in:
       indexed_reference_fasta: index_references/indexed_reference_fasta
       reference_dict: reference_dict
-      hg38_strelka_bed: index_references/indexed_hg38_strelka_bed
+      strelka2_bed: index_references/indexed_strelka2_bed
       input_tumor_aligned: input_tumor_aligned
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned
@@ -264,7 +268,7 @@ steps:
     in:
       indexed_reference_fasta: index_references/indexed_reference_fasta
       reference_dict: reference_dict
-      hg38_strelka_bed: index_references/indexed_hg38_strelka_bed
+      strelka2_bed: index_references/indexed_strelka2_bed
       input_tumor_aligned: input_tumor_aligned
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned

--- a/workflow/kfdrc_somatic_caller_workflow.cwl
+++ b/workflow/kfdrc_somatic_caller_workflow.cwl
@@ -138,6 +138,7 @@ inputs:
   # capture_regions: {type: ['null', File], doc: "If not WGS, provide this bed file"}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
   vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache", sbg:suggestedValue: {class: 'File', path: '5d9e3424e4b0950cce15fe6f', name: 'homo_sapiens_vep_93_GRCh38_convert_cache.tar.gz'}}
+  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   output_basename: string
   cfree_ploidy: {type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try"}
   cfree_mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
@@ -252,6 +253,7 @@ steps:
       exome_flag:
         valueFrom: ${return "N";}
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:
@@ -292,6 +294,7 @@ steps:
       exome_flag:
         valueFrom: ${return "N";}
       vep_cache: vep_cache
+      vep_ref_build: vep_ref_build
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:


### PR DESCRIPTION
Added ability to specify VEP ref version. Also fixed a reference_dict bug - was specified at wf level, but not sub wf level, causing failures to get reference_dict running mutect2. Also renamed strelka bed input var to be more accurate.