### PR TITLE
Mb fix exome flag

### DIFF
--- a/workflow/kfdrc_production_WES_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_WES_somatic_variant_cnv_wf.cwl
@@ -39,6 +39,7 @@ inputs:
     doc: "normal BAM or CRAM"
 
   input_normal_name: string
+  exome_flag: {type: string?, default: "Y", doc: "Whether to run in exome mode for callers. Should be Y or leave blank as default is Y. Only make N if you are certain"}
   cfree_threads: {type: ['null', int], doc: "For ControlFreeC.  Recommend 16 max, as I/O gets saturated after that losing any advantage.", default: 16}
   vardict_min_vaf: {type: ['null', float], doc: "Min variant allele frequency for vardict to consider.  Recommend 0.05", default: 0.05}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
@@ -113,8 +114,7 @@ steps:
     in:
       interval_list: padded_capture_regions
       reference_dict: reference_dict
-      exome_flag:
-        valueFrom: ${return "Y";}
+      exome_flag: exome_flag
       scatter_ct:
         valueFrom: ${return 50}
       bands:
@@ -258,8 +258,7 @@ steps:
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned
       input_normal_name: input_normal_name
-      exome_flag:
-        valueFrom: ${return "Y";}
+      exome_flag: exome_flag
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename
@@ -277,8 +276,7 @@ steps:
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned
       input_normal_name: input_normal_name
-      exome_flag:
-        valueFrom: ${return "Y";}
+      exome_flag: exome_flag
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename

--- a/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
+++ b/workflow/kfdrc_production_WGS_somatic_variant_cnv.cwl
@@ -39,6 +39,7 @@ inputs:
     doc: "normal BAM or CRAM"
 
   input_normal_name: string
+  exome_flag: {type: string?, default: "N", doc: "Whether to run in exome mode for callers. Should be N or leave blank as default is N. Only make Y if you are certain"}
   wgs_calling_interval_list: {type: File, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
   lancet_calling_interval_bed: {type: File, doc: "For WGS, highly recommended to use CDS bed, and supplement with region calls from strelka2 & mutect2.  Can still give calling list as bed if true WGS calling desired instead of exome+."}
   cfree_threads: {type: ['null', int], doc: "For ControlFreeC.  Recommend 16 max, as I/O gets saturated after that losing any advantage.", default: 16}
@@ -115,8 +116,7 @@ steps:
     in:
       interval_list: wgs_calling_interval_list
       reference_dict: reference_dict
-      exome_flag:
-        valueFrom: ${return "N";}
+      exome_flag: exome_flag
       scatter_ct:
         valueFrom: ${return 50}
       bands:
@@ -248,8 +248,7 @@ steps:
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned
       input_normal_name: input_normal_name
-      exome_flag:
-        valueFrom: ${return "N";}
+      exome_flag: exome_flag
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename
@@ -267,8 +266,7 @@ steps:
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned
       input_normal_name: input_normal_name
-      exome_flag:
-        valueFrom: ${return "N";}
+      exome_flag: exome_flag
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename


### PR DESCRIPTION
@zhangb1 found a bug where production exome wf strelak2 and mutect2 callers bot actually running in exome mode. After looking into it I have found that:
 if you look at the job.json, you see this:
`"exome_flag" : "Y",`
and it behaves as expected
but the strelka2 sub wf passed with to strelka2:
`"exome_flag" : "${return \"Y\";}",`

To fix this, I have instead set a `default` value at the top wf level in both WGS (which was accidentally running properly) and WES production workflows.  Bo has run a test here:
https://cavatica.sbgenomics.com/u/d3b-bixu/rs-14jwqpdg-pnoc003-omics-analysis/tasks/f8a6d056-c514-44ab-86c7-32d7451d0032/