### PR TITLE
:wrench: added bug fix to norm step discovered during WGSA work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ fabric.properties
 
 # Mac-specific
 .DS_Store
+
+# VS Code
+.vscode

--- a/tools/normalize_vcf.cwl
+++ b/tools/normalize_vcf.cwl
@@ -23,16 +23,15 @@ arguments:
       ${
           var cmd = " >&2 echo checking if strip flag given;";
           if (inputs.strip_info != null){
-            cmd += "(bcftools annotate -x " + inputs.strip_info + " " + inputs.input_vcf.path + " -o stripped.vcf &&"
-            cmd += "VCF=stripped.vcf && >&2 echo strip flag given) ||"
-            cmd += (" >&2 echo strip failed, ignoring;") 
+            cmd += ">&2 echo strip flag given; VCF=stripped.vcf;"
+            cmd += "bcftools annotate -x " + inputs.strip_info + " " + inputs.input_vcf.path + " -o $VCF"
+            cmd += " || VCF=" + inputs.input_vcf.path
           }else{
-            cmd += " >&2 echo no strip flag given;"
+            cmd += " >&2 echo no strip flag given"
           }
           return cmd;
       }
-
-      bcftools norm -m '-any' $VCF > $(inputs.output_basename).$(inputs.tool_name).bcf_norm.vcf
+      && bcftools norm -m '-any' $VCF > $(inputs.output_basename).$(inputs.tool_name).bcf_norm.vcf
       && /vt/vt normalize -n -r $(inputs.indexed_reference_fasta.path) $(inputs.output_basename).$(inputs.tool_name).bcf_norm.vcf
       > $(inputs.output_basename).$(inputs.tool_name).bcf_vt_norm.vcf
       && bgzip $(inputs.output_basename).$(inputs.tool_name).bcf_vt_norm.vcf


### PR DESCRIPTION
Issue explained in dev ticket:
https://app.zenhub.com/workspaces/d3b-bfx-5cdd720eed0dce4209e0b8a5/issues/d3b-center/bixu-tracker/527

Successful correct input run, old VEP info stripped and file normed:
https://cavatica.sbgenomics.com/u/d3b-bixu/dev-wgsa/tasks/577c36d8-7fb4-4516-bfd4-6c6025a9fa48/

Successful incorrect input run, old VEP info remains, but file is still normed:
https://cavatica.sbgenomics.com/u/d3b-bixu/dev-wgsa/tasks/dd36b20a-7d62-4df4-82c6-483147d415a7/