### PR TITLE
🤝 WGS and WXS WFs United

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--Pull Request Template-->
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+* Environment:
+* Test files:
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have checked my code and corrected any misspellings

--- a/tools/bedtools_intersect.cwl
+++ b/tools/bedtools_intersect.cwl
@@ -21,9 +21,6 @@ arguments:
       ${
           var cmd = " >&2 echo checking if skip intersect flag given;";
           var out_vcf = inputs.output_basename + ".bed_intersect.vcf";
-          if (inputs.input_vcf == null){
-            return "echo No vcf provided, skipping >&2 && exit 0;"
-          }
           if (inputs.flag != "N"){
             cmd += "bedtools intersect -a " + inputs.input_vcf.path + " -b " + inputs.input_bed_file.path + " -header -wa > " + out_vcf + " && ";
             cmd +=  "bgzip " + out_vcf + " && tabix " + out_vcf + ".gz;";
@@ -35,14 +32,14 @@ arguments:
       }
 
 inputs:
-    input_vcf: {type: File?, secondaryFiles: ['.tbi'], doc: "Made optional so that in a pipeline, this can be skipped"}
+    input_vcf: {type: File, secondaryFiles: ['.tbi'], doc: "Input VCF file"}
     input_bed_file: File
     output_basename: string
     flag: {type: ['null', string], doc: "If N, skip and pass through vcf without intersect"}
 
 outputs:
   intersected_vcf:
-    type: File?
+    type: File
     outputBinding:
       glob: '*.bed_intersect.vcf.gz'
     secondaryFiles: ['.tbi']

--- a/tools/bedtools_intersect.cwl
+++ b/tools/bedtools_intersect.cwl
@@ -21,6 +21,9 @@ arguments:
       ${
           var cmd = " >&2 echo checking if skip intersect flag given;";
           var out_vcf = inputs.output_basename + ".bed_intersect.vcf";
+          if (inputs.input_vcf == null){
+            return "echo No vcf provided, skipping >&2 && exit 0;"
+          }
           if (inputs.flag != "N"){
             cmd += "bedtools intersect -a " + inputs.input_vcf.path + " -b " + inputs.input_bed_file.path + " -header -wa > " + out_vcf + " && ";
             cmd +=  "bgzip " + out_vcf + " && tabix " + out_vcf + ".gz;";
@@ -32,14 +35,14 @@ arguments:
       }
 
 inputs:
-    input_vcf: {type: File, secondaryFiles: ['.tbi'], doc: "Input VCF file"}
+    input_vcf: {type: 'File?', secondaryFiles: ['.tbi'], doc: "Input VCF file. Skips if not provided."}
     input_bed_file: File
     output_basename: string
     flag: {type: ['null', string], doc: "If N, skip and pass through vcf without intersect"}
 
 outputs:
   intersected_vcf:
-    type: File
+    type: 'File?'
     outputBinding:
       glob: '*.bed_intersect.vcf.gz'
     secondaryFiles: ['.tbi']

--- a/tools/gatk_intervallisttool.cwl
+++ b/tools/gatk_intervallisttool.cwl
@@ -17,24 +17,29 @@ arguments:
       set -eo pipefail
       
       ${
-        var cmd = "";
-        if (inputs.interval_list.nameext == '.interval_list'){
-          cmd = "LIST=" + inputs.interval_list.path + ";";
+        if (inputs.interval_list == null) {
+          return "echo No interval list exiting without input >&2 && exit 0;";
         }
-        else{
-          cmd = "/gatk BedToIntervalList -I " + inputs.interval_list.path + " -O " + inputs.interval_list.nameroot 
-          + ".interval_list -SD " + inputs.reference_dict.path + "; LIST=" + inputs.interval_list.nameroot 
-          + ".interval_list;";
-
-        }
-        if (inputs.exome_flag == "Y"){
-            cmd += "BANDS=0;";
+        else {
+          var cmd = "";
+          if (inputs.interval_list.nameext == '.interval_list'){
+            cmd = "LIST=" + inputs.interval_list.path + ";";
           }
-          
-        else{
-          cmd += "BANDS=" + inputs.bands + ";";
+          else{
+            cmd = "/gatk BedToIntervalList -I " + inputs.interval_list.path + " -O " + inputs.interval_list.nameroot 
+            + ".interval_list -SD " + inputs.reference_dict.path + "; LIST=" + inputs.interval_list.nameroot 
+            + ".interval_list;";
+
+          }
+          if (inputs.exome_flag == "Y"){
+              cmd += "BANDS=0;";
+            }
+            
+          else{
+            cmd += "BANDS=" + inputs.bands + ";";
+          }
+          return cmd;
         }
-        return cmd;
       }
 
       ${
@@ -54,7 +59,7 @@ arguments:
       }
 
 inputs:
-  interval_list: File
+  interval_list: {type: 'File?'}
   bands: int
   scatter_ct: int
   reference_dict: {type: ['null', File], doc: "Provide only if input is bed file instead of gatk style .interval_list", sbg:suggestedValue: {name:  "Provide only if input is bed file instead of gatk style .interval_list"}}
@@ -62,7 +67,7 @@ inputs:
   break_by_chr: {type: ['null', string], doc: "If Y, break up files by chr.  If creating smaler intervals, recommend scatter_ct=1", default: "N"}
 outputs:
   output:
-    type: 'File[]'
+    type: 'File[]?'
     outputBinding:
       glob: '*.bed'
 

--- a/tools/mode_defaults.cwl
+++ b/tools/mode_defaults.cwl
@@ -11,7 +11,7 @@ arguments:
       Selecting $(inputs.input_mode) default values
 
 inputs:
-  input_mode: {type: {type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"}
+  input_mode: {type: {type: enum, name: "input_mode", symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"}
   exome_flag: {type: 'string?', doc: "Whether to run in exome mode for callers."}
   cnvkit_wgs_mode: {type: 'string?', doc: "Entering Y will run cnvkit in WGS mode, otherwise it will run in hybrid mode. Defaults to Y in wgs mode."}
   i_flag: {type: 'string?', doc: "Flag to intersect germline calls on padded regions.  Use N if you want to skip this. Defaults to N in WGS mode."}

--- a/tools/mode_defaults.cwl
+++ b/tools/mode_defaults.cwl
@@ -62,7 +62,7 @@ outputs:
       outputEval: >-
         ${
           if (inputs.lancet_window) { return inputs.lancet_window }
-          else if (inputs.input_mode == 'WGS') { return 500 }
+          else if (inputs.input_mode == 'WGS') { return 600 }
           else if (inputs.input_mode == 'WXS') { return 600 }
         }
   out_vardict_padding:

--- a/tools/mode_defaults.cwl
+++ b/tools/mode_defaults.cwl
@@ -53,7 +53,7 @@ outputs:
       outputEval: >-
         ${
           if (inputs.lancet_padding) { return inputs.lancet_padding }
-          if (inputs.input_mode == 'WGS') { return 300 }
+          else if (inputs.input_mode == 'WGS') { return 300 }
           else if (inputs.input_mode == 'WXS') { return 0 }
         }
   out_lancet_window:
@@ -62,7 +62,7 @@ outputs:
       outputEval: >-
         ${
           if (inputs.lancet_window) { return inputs.lancet_window }
-          if (inputs.input_mode == 'WGS') { return 500 }
+          else if (inputs.input_mode == 'WGS') { return 500 }
           else if (inputs.input_mode == 'WXS') { return 600 }
         }
   out_vardict_padding:
@@ -71,6 +71,6 @@ outputs:
       outputEval: >-
         ${
           if (inputs.vardict_padding) { return inputs.vardict_padding }
-          if (inputs.input_mode == 'WGS') { return 150 }
+          else if (inputs.input_mode == 'WGS') { return 150 }
           else if (inputs.input_mode == 'WXS') { return 0 }
         }

--- a/tools/mode_defaults.cwl
+++ b/tools/mode_defaults.cwl
@@ -1,0 +1,76 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: mode_defaults
+doc: "Selects the appropriate defaults based on given the mode"
+requirements:
+  - class: InlineJavascriptRequirement
+baseCommand: echo
+arguments:
+  - position: 0
+    valueFrom: >-
+      Selecting $(inputs.input_mode) default values
+
+inputs:
+  input_mode: {type: {type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"}
+  exome_flag: {type: 'string?', doc: "Whether to run in exome mode for callers."}
+  cnvkit_wgs_mode: {type: 'string?', doc: "Entering Y will run cnvkit in WGS mode, otherwise it will run in hybrid mode. Defaults to Y in wgs mode."}
+  i_flag: {type: 'string?', doc: "Flag to intersect germline calls on padded regions.  Use N if you want to skip this. Defaults to N in WGS mode."}
+  lancet_padding: {type: 'int?', doc: "Recommend 0 if interval file padded already, half window size if not. Recommended: 0 for WXS; 300 for WGS"}
+  lancet_window: {type: 'int?', doc: "window size for lancet.  default is 600, recommend 500 for WGS, 600 for exome+"}
+  vardict_padding: {type: 'int?', doc: "Padding to add to input intervals, recommend 0 if intervals already padded such as in WXS, 150 if not such as in WGS"}
+
+outputs:
+  out_exome_flag:
+    type: 'string?'
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.exome_flag) { return inputs.exome_flag }
+          else if (inputs.input_mode == 'WGS') { return 'N' }
+          else if (inputs.input_mode == 'WXS') { return 'Y' }
+        }
+  out_cnvkit_wgs_mode:
+    type: 'string?'
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.cnvkit_wgs_mode) { return inputs.cnvkit_wgs_mode }
+          else if (inputs.input_mode == 'WGS') { return 'Y' }
+          else if (inputs.input_mode == 'WXS') { return 'N' }
+        }
+  out_i_flag:
+    type: 'string?'
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.i_flag) { return inputs.i_flag }
+          else if (inputs.input_mode == 'WGS') { return 'N' }
+          else if (inputs.input_mode == 'WXS') { return null }
+        }
+  out_lancet_padding:
+    type: 'int?'
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.lancet_padding) { return inputs.lancet_padding }
+          if (inputs.input_mode == 'WGS') { return 300 }
+          else if (inputs.input_mode == 'WXS') { return 0 }
+        }
+  out_lancet_window:
+    type: 'int?'
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.lancet_window) { return inputs.lancet_window }
+          if (inputs.input_mode == 'WGS') { return 500 }
+          else if (inputs.input_mode == 'WXS') { return 600 }
+        }
+  out_vardict_padding:
+    type: 'int?'
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.vardict_padding) { return inputs.vardict_padding }
+          if (inputs.input_mode == 'WGS') { return 150 }
+          else if (inputs.input_mode == 'WXS') { return 0 }
+        }

--- a/tools/mode_selector.cwl
+++ b/tools/mode_selector.cwl
@@ -1,0 +1,39 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: mode_selector 
+doc: "Selects the appropriate input to serve as the output given the mode" 
+requirements:
+  - class: DockerRequirement
+    dockerPull: 'ubuntu:18.04'
+  - class: InlineJavascriptRequirement
+baseCommand: ["/bin/bash", "-c"]
+arguments:
+  - position: 0
+    valueFrom: >-
+      set -eo pipefail
+
+      ${
+          var cmd = " >&2 echo Choosing inputs based on mode;";
+          if (inputs.input_mode == 'WGS' && inputs.wgs_input == null){
+            return "echo WGS run requires wgs_input >&2 && exit 1;"
+          }
+          else if (inputs.input_mode == 'WXS' && inputs.wxs_input == null){
+            return "echo WXS run requires wxs_input >&2 && exit 1;"
+          }
+          return cmd;
+      }
+       
+inputs:
+  input_mode: {type: {type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"} 
+  wgs_input: {type: 'Any?', doc: "Input that should be passed when mode is WGS"}
+  wxs_input: {type: 'Any?', doc: "Input that should be passed when mode is WXS"}
+
+outputs:
+  output: 
+    type: Any 
+    outputBinding:
+      outputEval: >-
+        ${
+          if (inputs.input_mode == 'WGS') { return inputs.wgs_input }
+          else if (inputs.input_mode == 'WXS') { return inputs.wxs_input }
+        }

--- a/tools/mode_selector.cwl
+++ b/tools/mode_selector.cwl
@@ -24,7 +24,7 @@ arguments:
       }
        
 inputs:
-  input_mode: {type: {type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"} 
+  input_mode: {type: {type: enum, name: "input_mode", symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"}
   wgs_input: {type: 'Any?', doc: "Input that should be passed when mode is WGS"}
   wxs_input: {type: 'Any?', doc: "Input that should be passed when mode is WXS"}
 

--- a/tools/preprocess_lancet_intervals.cwl
+++ b/tools/preprocess_lancet_intervals.cwl
@@ -17,9 +17,13 @@ arguments:
       set -eo pipefail
 
       ${
-          var flag = 0
-          var cmd = "";
-          var bed = []
+        var flag = 0
+        var cmd = "";
+        var bed = []
+        if(inputs.ref_bed == null) {
+          return "echo No ref bed provided providing empty output >&2 && exit 0;"
+        }
+        else {
           if(inputs.strelka2_vcf != null){
               flag = 1;
               cmd += "gunzip -c " + inputs.strelka2_vcf.path + " > " + inputs.strelka2_vcf.basename + ";";
@@ -40,22 +44,23 @@ arguments:
               cmd += "vcf2bed --snvs < " + inputs.mutect2_vcf.basename +  " | cut -f 1-3 > mutect2.snvs.bed;";
               bed.push("mutect2.snvs.bed");
           }
-        if(flag == 0){
-            cmd += "echo \"No input vcfs found to convert.  Returning ref bed\"; cp " + inputs.ref_bed.path + " " + inputs.output_basename + ".lancet_intvervals.bed;";
+          if(flag == 0){
+              cmd += "echo \"No input vcfs found to convert.  Returning ref bed\"; cp " + inputs.ref_bed.path + " " + inputs.output_basename + ".lancet_intvervals.bed;";
+          }
+          else{
+              cmd += "cat " + bed.join(" ") + " " + inputs.ref_bed.path + " | bedtools sort | bedtools merge > " + inputs.output_basename + ".lancet_intvervals.bed;";
+          }
+          return cmd;
         }
-        else{
-            cmd += "cat " + bed.join(" ") + " " + inputs.ref_bed.path + " | bedtools sort | bedtools merge > " + inputs.output_basename + ".lancet_intvervals.bed;";
-        }
-        return cmd;
       }
 
 inputs:
   strelka2_vcf: {type: ['null', File], doc: "PASS vcf from strelka2 run for the sample to be analyzed"}
   mutect2_vcf: {type: ['null', File], doc: "PASS vcf from mutect2 run for the sample to be analyzed"}
-  ref_bed: {type: File, doc: "Exonic bed file recommended.  Will be augmented with strelka2 and/or mutect2 sites if supplied"}
+  ref_bed: {type: 'File?', doc: "Optional exonic bed file recommended.  Will be augmented with strelka2 and/or mutect2 sites if supplied"}
   output_basename: string
 outputs:
   run_bed:
-    type: File
+    type: 'File?'
     outputBinding:
       glob: '*.lancet_intvervals.bed'

--- a/tools/python_vardict_interval_split.cwl
+++ b/tools/python_vardict_interval_split.cwl
@@ -30,6 +30,7 @@ arguments:
                 f = 0
                 if i not in intvl_set:
                     intvl_set[i] = []
+                # chr(9) is ASCII code for tab; chr(10) is ASCII code for newline
                 data = cur_intvl.rstrip(chr(10)).split(chr(9))
                 (chrom, start, end) = (data[0], data[1], data[2])
                 intvl_size = int(end) - int(start)

--- a/tools/python_vardict_interval_split.cwl
+++ b/tools/python_vardict_interval_split.cwl
@@ -15,6 +15,7 @@ requirements:
 baseCommand: [python, -c]
 arguments:
   - position: 0
+    shellQuote: true
     valueFrom: >-
         def main():
             import sys
@@ -29,7 +30,7 @@ arguments:
                 f = 0
                 if i not in intvl_set:
                     intvl_set[i] = []
-                data = cur_intvl.rstrip("\n").split("\t")
+                data = cur_intvl.rstrip(chr(10)).split(chr(9))
                 (chrom, start, end) = (data[0], data[1], data[2])
                 intvl_size = int(end) - int(start)
                 if intvl_size >= bp_target:
@@ -61,8 +62,8 @@ arguments:
                         new_end = j + intvl_target_size
                         if new_end > int(end):
                             new_end = end
-                        out.write(chrom + "\t" + str(j) + "\t" + str(new_end) + "\n")
-                sys.stderr.write("Set " + str(set_i) + " size:\t" + str(set_size) + "\n")
+                        out.write(chrom + chr(9) + str(j) + chr(9) + str(new_end) + chr(10))
+                sys.stderr.write("Set " + str(set_i) + " size:" + chr(9) + str(set_size) + chr(10))
                 out.close()
 
         if __name__ == "__main__":

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -232,6 +232,14 @@ steps:
     out:
       [vardict_vep_somatic_only_vcf, vardict_vep_somatic_only_tbi, vardict_vep_somatic_only_maf, vardict_prepass_vcf]
 
+  select_mutect_bed_interval:
+    run: ../tools/mode_selector.cwl
+    in:
+      input_mode: wgs_or_wxs
+      wgs_input: gatk_intervallisttools/output
+      wxs_input: gatk_intervallisttools/output
+    out: [output]
+
   run_mutect2:
     hints:
       - class: 'sbg:AWSInstanceType'
@@ -240,7 +248,7 @@ steps:
     in:
       indexed_reference_fasta: indexed_reference_fasta
       reference_dict: reference_dict
-      bed_invtl_split: gatk_intervallisttools/output
+      bed_invtl_split: select_mutect_bed_interval/output
       af_only_gnomad_vcf: mutect2_af_only_gnomad_vcf
       exac_common_vcf: mutect2_exac_common_vcf
       input_tumor_aligned: input_tumor_aligned

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -1,11 +1,12 @@
 cwlVersion: v1.0
 class: Workflow
-id: kfdrc_production_somatic_wgs_variant_cnv_wf
+id: kfdrc_production_somatic_variant_cnv_wf
 requirements:
   - class: ScatterFeatureRequirement
   - class: MultipleInputFeatureRequirement
   - class: SubworkflowFeatureRequirement
 inputs:
+  # Required
   indexed_reference_fasta: {type: File, secondaryFiles: [.fai, ^.dict]}
   reference_fai: File
   reference_dict: File
@@ -22,7 +23,6 @@ inputs:
         }
       }
     doc: "tumor BAM or CRAM"
-
   input_tumor_name: string
   input_normal_aligned:
     type: File
@@ -37,40 +37,53 @@ inputs:
         }
       }
     doc: "normal BAM or CRAM"
-
   input_normal_name: string
-  exome_flag: {type: string?, default: "N", doc: "Whether to run in exome mode for callers. Should be N or leave blank as default is N. Only make Y if you are certain"}
-  wgs_calling_interval_list: {type: File, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
-  lancet_calling_interval_bed: {type: File, doc: "For WGS, highly recommended to use CDS bed, and supplement with region calls from strelka2 & mutect2.  Can still give calling list as bed if true WGS calling desired instead of exome+."}
-  cfree_threads: {type: ['null', int], doc: "For ControlFreeC.  Recommend 16 max, as I/O gets saturated after that losing any advantage.", default: 16}
-  vardict_min_vaf: {type: ['null', float], doc: "Min variant allele frequency for vardict to consider.  Recommend 0.05", default: 0.05}
-  select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
-  vardict_cpus: {type: ['null', int], default: 9}
-  vardict_ram: {type: ['null', int], default: 18, doc: "In GB"}
-  lancet_ram: {type: ['null', int], default: 12, doc: "Adjust in rare circumstances in which 12 GB is not enough"}
-  lancet_window: {type: ['null', int], doc: "window size for lancet.  default is 600, recommend 500 for WGS, 600 for exome+", default: 600}
-  lancet_padding: {type: ['null', int], doc: "Recommend 0 if interval file padded already, half window size if not", default: 300}
-  vardict_padding: {type: ['null', int], doc: "Padding to add to input intervals, recommened 0 if intervals already padded, 150 if not", default: 150}
   vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
-  vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   cfree_chr_len: {type: File, doc: "file with chromosome lengths"}
   cfree_ploidy: {type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try"}
-  cfree_mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
-  cfree_mate_orientation_control: {type: ['null', {type: enum, name: mate_orientation_control, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
-  b_allele: {type: ['null', File], secondaryFiles: ['.tbi'],  doc: "germline calls, needed for BAF.  GATK HC VQSR input recommended.  Tool will prefilter for germline and pass if expression given"}
+  cnvkit_annotation_file: {type: File, doc: "refFlat.txt file"}
+  hg38_strelka_bed: {type: File, secondaryFiles: ['.tbi'], doc: "Bgzipped interval bed file. Recommned padding 100bp for WXS; Recommend canonical chromosomes for WGS"}
   mutect2_af_only_gnomad_vcf: {type: File, secondaryFiles: ['.tbi']}
   mutect2_exac_common_vcf: {type: File, secondaryFiles: ['.tbi']}
-  hg38_strelka_bed: {type: File, secondaryFiles: ['.tbi'], doc: "Bgzipped interval bed file. Recommend canonical chromosomes"}
-  cnvkit_annotation_file: {type: File, doc: "refFlat.txt file"}
-  cnvkit_wgs_mode: {type: ['null', string], doc: "for WGS mode, input Y. leave blank for hybrid mode", default: "Y"}
-  cfree_coeff_var: {type: ['null', float], default: 0.05, doc: "Coefficient of variation to set window size.  Default 0.05 recommended"}
-  cfree_contamination_adjustment: {type: ['null', boolean], doc: "TRUE or FALSE to have ControlFreec estimate normal contam"}
-  combined_include_expression: {type: ['null', string], doc: "Filter expression if vcf has non-PASS combined calls, use as-needed, i.e. for VarDict: FILTER=\"PASS\" && (INFO/STATUS=\"Germline\" | INFO/STATUS=\"StrongSomatic\")"}
-  combined_exclude_expression: {type: ['null', string], doc: "Filter expression if vcf has non-PASS combined calls, use as-needed"}  
-  min_theta2_frac: {type: ['null', float], doc: "Minimum fraction of genome with copy umber alterations.  Default is 0.05, recommend 0.01", default: 0.01}
+  output_basename: {type: string, doc: "String value to use as basename for outputs"}
+  wgs_or_wxs: {type: {type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS"}  
+
+  # Optional with One Default
+  cfree_threads: {type: 'int?', default: 16, doc: "For ControlFreeC. Recommend 16 max, as I/O gets saturated after that losing any advantage"}
+  cfree_mate_orientation_control: {type: ['null', {type: enum, name: mate_orientation_control, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
+  cfree_mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
+  lancet_ram: {type: 'int?', default: 12, doc: "Adjust in rare circumstances in which 12 GB is not enough"}
+  select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], default: "gatk", doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression"}
+  min_theta2_frac: {type: 'float?', default: 0.01, doc: "Minimum fraction of genome with copy umber alterations.  Default is 0.05, recommend 0.01"}
+  vardict_cpus: {type: 'int?', default: 9, doc: "Number of CPUs for Vardict to use"}
+  vardict_min_vaf: {type: 'float?', default: 0.05, doc: "Min variant allele frequency for vardict to consider. Recommend 0.05"}
+  vardict_ram: {type: 'int?', default: 18, doc: "GB of RAM to allocate to Vardict"}
+  vep_ref_build: {type: 'string?', default: "GRCh38", doc: "Genome ref build used, should line up with cache"}
+
+  # Optional with Multiple Defaults (handled in choose_defaults)
+  exome_flag: {type: string?, doc: "Whether to run in exome mode for callers. Y for WXS, N for WGS"}
+  lancet_window: {type: 'int?', doc: "Window size for lancet.  Recommend 500 for WGS; 600 for exome+"}
+  lancet_padding: {type: 'int?', doc: "Recommend 0 if interval file padded already, half window size if not. Recommended: 0 for WXS; 300 for WGS"}
+  vardict_padding: {type: 'int?', doc: "Padding to add to input intervals, recommend 0 if intervals already padded such as in WXS, 150 if not such as in WGS"}
+  cnvkit_wgs_mode: {type: 'string?', doc: "for WGS mode, input Y. leave blank for WXS/hybrid mode"}
+  i_flag: {type: 'string?', doc: "Flag to intersect germline calls on padded regions. Use N if you want to skip this or have a WGS run"}
+
+  # Optional
+  b_allele: {type: 'File?', secondaryFiles: ['.tbi'],  doc: "germline calls, needed for BAF.  GATK HC VQSR input recommended.  Tool will prefilter for germline and pass if expression given"}
+  cfree_coeff_var: {type: 'float?', default: 0.05, doc: "Coefficient of variation to set window size.  Default 0.05 recommended"}
+  cfree_contamination_adjustment: {type: 'boolean?', doc: "TRUE or FALSE to have ControlFreec estimate normal contam"}
   cfree_sex: {type: ['null', {type: enum, name: sex, symbols: ["XX", "XY"] }], doc: "If known, XX for female, XY for male"}
-  cnvkit_sex: {type: ['null', string ], doc: "If known, choices are m,y,male,Male,f,x,female,Female"}
-  output_basename: string
+  cnvkit_sex: {type: 'string?', doc: "If known, choices are m,y,male,Male,f,x,female,Female"}
+  combined_include_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed, i.e. for VarDict: FILTER=\"PASS\" && (INFO/STATUS=\"Germline\" | INFO/STATUS=\"StrongSomatic\")"}
+  combined_exclude_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed"}
+
+  # WGS only Fields
+  wgs_calling_interval_list: {type: File?, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
+  lancet_calling_interval_bed: {type: File?, doc: "For WGS, highly recommended to use CDS bed, and supplement with region calls from strelka2 & mutect2.  Can still give calling list as bed if true WGS calling desired instead of exome+"}
+
+  # WXS only Fields
+  padded_capture_regions: {type: 'File?', doc: "Recommend 100bp pad, for somatic variant"}
+  unpadded_capture_regions: {type: 'File?', doc: "Capture regions with NO padding for cnv calling"}
 
 outputs:
   ctrlfreec_pval: {type: File, outputSource: run_controlfreec/ctrlfreec_pval}
@@ -111,19 +124,49 @@ outputs:
   lancet_prepass_vcf: {type: File, outputSource: run_lancet/lancet_prepass_vcf}
 
 steps:
+  choose_defaults:
+    run: ../tools/mode_defaults.cwl
+    in:
+      input_mode: wgs_or_wxs
+      exome_flag: exome_flag
+      cnvkit_wgs_mode: cnvkit_wgs_mode
+      i_flag: i_flag
+      lancet_padding: lancet_padding
+      lancet_window: lancet_window
+      vardict_padding: vardict_padding
+    out: [out_exome_flag,out_cnvkit_wgs_mode,out_i_flag,out_lancet_padding,out_lancet_window,out_vardict_padding]
+  select_interval_list:
+    run: ../tools/mode_selector.cwl
+    in:
+      input_mode: wgs_or_wxs
+      wgs_input: wgs_calling_interval_list 
+      wxs_input: padded_capture_regions 
+    out: [output]
+
+  # WGS only
   python_vardict_interval_split:
     run: ../tools/python_vardict_interval_split.cwl
     doc: "Custom interval list generation for vardict input. Briefly, ~60M bp per interval list, 20K bp intervals, lists break on chr and N reginos only"
     in:
-      wgs_bed_file: wgs_calling_interval_list
+      wgs_bed_file: select_interval_list/output
     out: [split_intervals_bed]
-  
+
+  bedtools_intersect_germline:
+    run: ../tools/bedtools_intersect.cwl
+    in:
+      input_vcf: b_allele
+      output_basename: output_basename
+      input_bed_file: unpadded_capture_regions
+      flag: choose_defaults/out_i_flag
+    out:
+      [intersected_vcf]
+
   gatk_intervallisttools:
     run: ../tools/gatk_intervallisttool.cwl
     in:
-      interval_list: wgs_calling_interval_list
+      interval_list: select_interval_list/output
       reference_dict: reference_dict
-      exome_flag: exome_flag
+      exome_flag: choose_defaults/out_exome_flag
       scatter_ct:
         valueFrom: ${return 50}
       bands:
@@ -133,7 +176,7 @@ steps:
   gatk_filter_germline:
     run: ../tools/gatk_filter_germline_variant.cwl
     in:
-      input_vcf: b_allele
+      input_vcf: bedtools_intersect_germline/intersected_vcf
       reference_fasta: indexed_reference_fasta
       output_basename: output_basename
     out:
@@ -157,6 +200,14 @@ steps:
       reference: indexed_reference_fasta
     out: [bam_file]
 
+  select_vardict_bed_interval:
+    run: ../tools/mode_selector.cwl
+    in:
+      input_mode: wgs_or_wxs
+      wgs_input: python_vardict_interval_split/split_intervals_bed
+      wxs_input: gatk_intervallisttools/output
+    out: [output]
+
   run_vardict:
     hints:
       - class: 'sbg:AWSInstanceType'
@@ -170,8 +221,8 @@ steps:
       input_normal_name: input_normal_name
       output_basename: output_basename
       reference_dict: reference_dict
-      bed_invtl_split: python_vardict_interval_split/split_intervals_bed
-      padding: vardict_padding
+      bed_invtl_split: select_vardict_bed_interval/output
+      padding: choose_defaults/out_vardict_padding
       min_vaf: vardict_min_vaf
       select_vars_mode: select_vars_mode
       cpus: vardict_cpus
@@ -196,7 +247,7 @@ steps:
       input_tumor_name: input_tumor_name
       input_normal_aligned: input_normal_aligned
       input_normal_name: input_normal_name
-      exome_flag: exome_flag
+      exome_flag: choose_defaults/out_exome_flag
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename
@@ -244,6 +295,14 @@ steps:
         valueFrom: ${return 80000000}
     out: [output]
 
+  select_lancet_bed_inteval:
+    run: ../tools/mode_selector.cwl
+    in:
+      input_mode: wgs_or_wxs
+      wgs_input: gatk_intervallisttools_exome_plus/output 
+      wxs_input: gatk_intervallisttools/output
+    out: [output]
+
   run_lancet:
     hints:
       - class: 'sbg:AWSInstanceType'
@@ -258,10 +317,10 @@ steps:
       output_basename: output_basename
       select_vars_mode: select_vars_mode
       reference_dict: reference_dict
-      bed_invtl_split: gatk_intervallisttools_exome_plus/output
+      bed_invtl_split: select_lancet_bed_inteval/output
       ram: lancet_ram
-      window: lancet_window
-      padding: lancet_padding
+      window: choose_defaults/out_lancet_window
+      padding: choose_defaults/out_lancet_padding
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
     out:
@@ -278,6 +337,7 @@ steps:
       ploidy: cfree_ploidy
       mate_orientation_sample: cfree_mate_orientation_sample
       mate_orientation_control: cfree_mate_orientation_control
+      capture_regions: unpadded_capture_regions
       indexed_reference_fasta: indexed_reference_fasta
       reference_fai: reference_fai
       b_allele: gatk_filter_germline/filtered_pass_vcf
@@ -296,7 +356,8 @@ steps:
       input_normal_aligned: samtools_cram2bam_plus_calmd_normal/bam_file
       reference: indexed_reference_fasta
       normal_sample_name: input_normal_name
-      wgs_mode: cnvkit_wgs_mode
+      capture_regions: unpadded_capture_regions
+      wgs_mode: choose_defaults/out_cnvkit_wgs_mode
       b_allele_vcf: gatk_filter_germline/filtered_pass_vcf
       annotation_file: cnvkit_annotation_file
       output_basename: output_basename


### PR DESCRIPTION
## Description

This PR creates minimal workflow that can run both WGS and WXS versions of the kfdrc production somatic workflow per https://github.com/d3b-center/bixu-tracker/issues/593.

General description of changes:
- Added functionality to preprocess_lancet_intervals and gatk_intervallisttool to skip the step if the input is not provided. This was needed on account of this lancet interval preprocessing only occuring in WGS. The pass through allows WXS to go through these steps without failure.
- Created two new tools to handle defaults and mode specific files. mode_defaults simply rescues the default functionality that is lost when we were able to specify defaults specific to WGS and WXS. mode_selector is for instances where WGS and WXS disagree on which file to pass to a subsequent step. The tool will make the selection based on what mode it is in.
- python_vardict_interval_split received globalization changes that have come up recently. Specifically, shellQuote is speficied true for cwl interpreters other than rabix that would normally default this value to false and escape characters were removed from the argument block to allow appropriate processing in cwltool.
- the WES and WGS wfs got cosmetic changes so that the differences in the wfs would be easier to visualize using diff or vimdiff
- added new unified wf

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Passes local validation using cwltool
- [x] Tested WXS portion on Cavatica: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-8y99qzjj/tasks/0e0718fe-0828-4084-b4c8-f444b9f114a9/
- [x] WGS test: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-8y99qzjj/tasks/31b79155-99ab-4b72-88a0-f6915953890f/#

**Test Configuration**:
* Environment: cwltool 3.0.20200324120055, Cavatica
* Test files: see Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings