### PR TITLE
🌐 optionally index inputs

### DIFF
--- a/sub_workflows/prepare_reference.cwl
+++ b/sub_workflows/prepare_reference.cwl
@@ -1,0 +1,62 @@
+cwlVersion: v1.0
+class: Workflow
+id: kfdrc_prepare_reference
+requirements:
+  - class: ScatterFeatureRequirement
+  - class: MultipleInputFeatureRequirement
+
+inputs:
+  input_fasta: File
+  input_fai: { type: 'File?' }
+  input_dict: { type: 'File?' }
+  input_alt: { type: 'File?' }
+  input_amb: { type: 'File?' }
+  input_ann: { type: 'File?' }
+  input_bwt: { type: 'File?' }
+  input_pac: { type: 'File?' }
+  input_sa: { type: 'File?' }
+  generate_bwa_indexes: { type: 'boolean?' }
+
+outputs:
+  indexed_fasta: { type: File, doc: "Reference fasta with all available indexes as secondaryFiles", outputSource: bundle_secondaries/output } 
+  reference_dict: { type: File, doc: "Standalone reference dict", outputSource: picard_create_sequence_dictionary/dict }
+
+steps:
+  samtools_faidx:
+    run: ../tools/samtools_faidx.cwl
+    in:
+      input_fasta: input_fasta
+      input_index: input_fai
+    out: [fai]
+  picard_create_sequence_dictionary:
+    run: ../tools/picard_createsequencedictionary.cwl
+    in:
+      input_fasta: input_fasta
+      input_dict: input_dict
+    out: [dict]
+  bwa_index:
+    run: ../tools/bwa_index.cwl
+    in:
+      generate_bwa_indexes: generate_bwa_indexes
+      input_fasta: input_fasta
+      input_alt: input_alt
+      input_amb: input_amb
+      input_ann: input_ann
+      input_bwt: input_bwt
+      input_pac: input_pac
+      input_sa: input_sa
+    out: [alt,amb,ann,bwt,pac,sa]
+  bundle_secondaries:
+    run: ../tools/bundle_secondaryfiles.cwl
+    in:
+      primary_file: input_fasta
+      secondary_files:
+        source: [samtools_faidx/fai,picard_create_sequence_dictionary/dict,bwa_index/alt,bwa_index/amb,bwa_index/ann,bwa_index/bwt,bwa_index/pac,bwa_index/sa]
+        linkMerge: merge_flattened
+    out: [output]
+
+$namespaces:
+  sbg: https://sevenbridges.com
+hints:
+  - class: sbg:maxNumberOfParallelInstances
+    value: 2

--- a/tools/bundle_secondaryfiles.cwl
+++ b/tools/bundle_secondaryfiles.cwl
@@ -1,0 +1,19 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: bundle_secondaryfiles 
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+  - class: ShellCommandRequirement
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.primary_file),$(inputs.secondary_files)]
+baseCommand: [echo]
+inputs:
+  primary_file: { type: File, doc: "Primary File" }
+  secondary_files: { type: 'File[]', doc: "List of secondary files" }
+outputs:
+  output: 
+    type: File
+    outputBinding:
+      glob: $(inputs.primary_file.basename)
+    secondaryFiles: ${var arr = []; for (i = 0; i < inputs.secondary_files.length; i++) { if (inputs.secondary_files[i]) { arr.push(inputs.secondary_files[i].basename) } }; return arr}

--- a/tools/bundle_secondaryfiles.cwl
+++ b/tools/bundle_secondaryfiles.cwl
@@ -1,6 +1,9 @@
 cwlVersion: v1.0
 class: CommandLineTool
 id: bundle_secondaryfiles 
+doc: |-
+  This tool takes a primary file and list of secondary files as input and passes the primary_file as
+  the output with the secondary_files as secondaryFiles.
 requirements:
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -1,6 +1,11 @@
 class: CommandLineTool
 cwlVersion: v1.0
 id: bwa_index
+doc: |-
+  This tool conditionally generates the bwa 64 indexes for an input fasta file using bwa index.
+  The tool will generate the indexes only of generate_bwa_indexes is set to true AND any of the alt,
+  amb, ann, bwt, pac, or sa files is missing.
+  The tool returns the six indexes as its output.
 requirements:
   - class: ShellCommandRequirement
   - class: ResourceRequirement

--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -1,0 +1,56 @@
+class: CommandLineTool
+cwlVersion: v1.0
+id: bwa_index
+requirements:
+  - class: ShellCommandRequirement
+  - class: ResourceRequirement
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.input_alt),$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/bwa:0.7.17-dev'
+  - class: InlineJavascriptRequirement
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_alt && inputs.input_amb && inputs.input_ann && inputs.input_bwt && inputs.input_pac && inputs.input_sa ? 'echo bwa' : inputs.generate_bwa_indexes ? 'bwa' : 'echo bwa')
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      index -6 -a bwtsw 
+inputs:
+  generate_bwa_indexes: { type: 'boolean?' }
+  input_fasta: { type: File, inputBinding: { position: 2 } }
+  input_alt: { type: 'File?' }
+  input_amb: { type: 'File?' }
+  input_ann: { type: 'File?' }
+  input_bwt: { type: 'File?' }
+  input_pac: { type: 'File?' }
+  input_sa: { type: 'File?' }
+
+outputs:
+  alt:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.alt'
+  amb:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.amb'
+  ann:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.ann'
+  bwt:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.bwt'
+  pac:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.pac'
+  sa:
+    type: 'File?'
+    outputBinding:
+      glob: '*.64.sa'

--- a/tools/gatk_indexfeaturefile.cwl
+++ b/tools/gatk_indexfeaturefile.cwl
@@ -1,0 +1,38 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: gatk_indexfeaturefile
+doc: "Creates an index for a feature file, e.g. VCF or BED file."
+requirements:
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.input_file),$(inputs.input_index)]
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+  - class: ShellCommandRequirement
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_index ? 'echo /gatk' : '/gatk')
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      IndexFeatureFile 
+inputs:
+  input_file:
+    type: File
+    doc: "Feature file (eg., VCF or BED file) to index. Must be in a tribble-supported format"
+    inputBinding:
+      position: 2
+      prefix: "-I"
+  input_index:
+    type: 'File?'
+    doc: "Index file for the input_file, if one exists"
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: $(inputs.input_file.basename)
+    secondaryFiles: ${if (inputs.input_file.nameext == '.vcf') {return inputs.input_file.basename+'.idx'} else if (inputs.input_file.nameext == '.gz') {return inputs.input_file.basename+'.tbi'}}

--- a/tools/picard_createsequencedictionary.cwl
+++ b/tools/picard_createsequencedictionary.cwl
@@ -1,0 +1,34 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: picard_createsequencedictionary
+requirements:
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.input_fasta),$(inputs.input_dict)]
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+  - class: ShellCommandRequirement
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_dict ? 'echo java -jar /gatk-package-4.1.7.0-local.jar' : 'java -jar /gatk-package-4.1.7.0-local.jar' )
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      CreateSequenceDictionary
+inputs:
+  input_fasta:
+    type: File
+    inputBinding:
+      position: 2
+      prefix: "-R"
+  input_dict:
+    type: 'File?'
+outputs:
+  dict:
+    type: File
+    outputBinding:
+      glob: "*.dict" 

--- a/tools/picard_createsequencedictionary.cwl
+++ b/tools/picard_createsequencedictionary.cwl
@@ -1,6 +1,10 @@
 cwlVersion: v1.0
 class: CommandLineTool
 id: picard_createsequencedictionary
+doc: |-
+  This tool conditionally creats a sequence dictionary from an input fasta using Picard CreateSequenceDictionary.
+  The tool will only generate the index if an the input_dict is not passed.
+  The tool returnts the dict as its only output.
 requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.7.0R'

--- a/tools/samtools_faidx.cwl
+++ b/tools/samtools_faidx.cwl
@@ -1,0 +1,29 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: samtools_faidx
+doc: |-
+  This tool takes an input fasta and optionally a input index for the input fasta.
+  If the index is not provided this tool will generate one.
+  Finally the tool will return the input reference file with the index (generated or provided) as a secondaryFile.
+requirements:
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/samtools:1.9'
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.input_fasta),$(inputs.input_index)]
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+  - class: ShellCommandRequirement
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_index ? 'echo samtools faidx' : 'samtools faidx' )
+inputs:
+  input_fasta: { type: File, inputBinding: { position: 1 }, doc: "Input fasta file" }
+  input_index: { type: 'File?', doc: "Input fasta index" }
+outputs:
+  fai: 
+    type: File
+    outputBinding:
+      glob: "*.fai" 

--- a/tools/tabix_index.cwl
+++ b/tools/tabix_index.cwl
@@ -1,0 +1,32 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: tabix_index 
+doc: >-
+  This tool will run tabix conditionally dependent on whether an index is provided.
+  The tool will output the input_file with the index, provided or created within, as a secondary file.
+requirements:
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/samtools:1.9'
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.input_file),$(inputs.input_index)]
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+  - class: ShellCommandRequirement
+
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_index ? 'echo tabix -p vcf' : 'tabix -p vcf')
+
+inputs:
+  input_file: { type: 'File', doc: "Position sorted and compressed by bgzip input file", inputBinding: { position: 1, shellQuote: false } }
+  input_index: { type: 'File?', doc: "Index file for the input_file, if one exists" }
+
+outputs:
+  output: 
+    type: File
+    outputBinding:
+      glob: $(inputs.input_file.basename) 
+    secondaryFiles: [.tbi]


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This update changes the way reference inputs and their indexes are handled in the somatic workflow. Rather than having indexes be passed as secondaryFiles, they can be optionally provided as their own inputs. If indexes are not provided an indexing step will occur for their main file. This change resolves issues with passing secondaryFiles to users using Cavatica suggested file links.

Resolves https://github.com/d3b-center/bixu-tracker/issues/670

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] WF passes local cwltool validation
- [x] Cavatica test: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-8y99qzjj/tasks/10a6e9d6-f48b-4b82-8828-432bfa695d17/#

**Test Configuration**:
* Environment: cwltool 3.0.20200324120055, Cavatica
* Test files: see Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings