### PR TITLE
🔧 fix double alt listing

### DIFF
--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -10,7 +10,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: ResourceRequirement
   - class: InitialWorkDirRequirement
-    listing: [$(inputs.input_alt),$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
+    listing: [$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
   - class: DockerRequirement
     dockerPull: 'kfdrc/bwa:0.7.17-dev'
   - class: InlineJavascriptRequirement


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Bug discovered in my alignment runs in the bwa index tool. Listing input_alt twice generates a javascript error. This fixes that error

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] New tool tested in alignment: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/08705e71-0b4a-4811-9bbd-43997a706cf5/

**Test Configuration**:
* Environment: Cavatica
* Test files: see Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
