### PR TITLE
🧠 Memory Tweeking

### DIFF
--- a/sub_workflows/kfdrc_lancet_sub_wf.cwl
+++ b/sub_workflows/kfdrc_lancet_sub_wf.cwl
@@ -31,6 +31,9 @@ outputs:
 steps:
   lancet:
     run: ../tools/lancet.cwl
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     in:
       input_tumor_bam: input_tumor_aligned
       input_normal_bam: input_normal_aligned

--- a/sub_workflows/kfdrc_manta_sub_wf.cwl
+++ b/sub_workflows/kfdrc_manta_sub_wf.cwl
@@ -40,6 +40,7 @@ inputs:
   input_normal_name: string
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
   output_basename: string
+  manta_memory: {type: int?}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
 outputs:
@@ -54,6 +55,7 @@ steps:
       input_tumor_cram: input_tumor_aligned
       input_normal_cram: input_normal_aligned
       output_basename: output_basename
+      ram: manta_memory
       reference: indexed_reference_fasta
       hg38_strelka_bed: hg38_strelka_bed
     out: [output_sv, small_indels]

--- a/sub_workflows/kfdrc_mutect2_filter_support_subwf.cwl
+++ b/sub_workflows/kfdrc_mutect2_filter_support_subwf.cwl
@@ -38,6 +38,8 @@ inputs:
     doc: "normal BAM or CRAM"
 
   exac_common_vcf: {type: File, secondaryFiles: [.tbi]}
+  getpileup_memory: {type: int?}
+  learnorientation_memory: {type: int?}
   output_basename: string
   f1r2_counts: {type: "File[]", doc: "orientation counts from mutect2 outputs"}
 
@@ -56,6 +58,7 @@ steps:
       output_basename: output_basename
       tool_name:
         valueFrom: ${return "mutect2"}
+      max_memory: learnorientation_memory
     out: [f1r2_bias]
 
   gatk_get_tumor_pileup_summaries:
@@ -66,6 +69,7 @@ steps:
       reference: indexed_reference_fasta
       interval_list: wgs_calling_interval_list
       exac_common_vcf: exac_common_vcf
+      max_memory: getpileup_memory
     scatter: [interval_list]
     out: [pileup_table]
 
@@ -78,6 +82,7 @@ steps:
       reference: indexed_reference_fasta
       interval_list: wgs_calling_interval_list
       exac_common_vcf: exac_common_vcf
+      max_memory: getpileup_memory
     scatter: [interval_list]
     out: [pileup_table]
 

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -56,10 +56,13 @@ outputs:
   mutect2_vep_vcf: {type: File, outputSource: vep_annot_mutect2/output_vcf}
   mutect2_vep_tbi: {type: File, outputSource: vep_annot_mutect2/output_tbi}
   mutect2_vep_maf: {type: File, outputSource: vep_annot_mutect2/output_maf}
-  
+
 steps:
   mutect2:
     run: ../tools/gatk_Mutect2.cwl
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     in:
       input_tumor_aligned: input_tumor_aligned
       input_tumor_name: input_tumor_name
@@ -105,7 +108,7 @@ steps:
       input_stats: mutect2/mutect_stats
       output_basename: output_basename
     out: [merged_stats]
-  
+
   filter_mutect2_vcf:
     run: ../tools/gatk_filtermutectcalls.cwl
     in:

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -46,6 +46,8 @@ inputs:
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
   vep_ref_build: {type: ['null', string], doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
   output_basename: string
+  getpileup_memory: {type: int?}
+  learnorientation_memory: {type: int?}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
 outputs:
@@ -81,6 +83,8 @@ steps:
       exac_common_vcf: exac_common_vcf
       output_basename: output_basename
       f1r2_counts: mutect2/f1r2_counts
+      getpileup_memory: getpileup_memory
+      learnorientation_memory: learnorientation_memory
     out: [contamination_table, segmentation_table, f1r2_bias]
 
   merge_mutect2_vcf:

--- a/sub_workflows/kfdrc_vardict_sub_wf.cwl
+++ b/sub_workflows/kfdrc_vardict_sub_wf.cwl
@@ -32,6 +32,9 @@ steps:
 
   vardict:
     run: ../tools/vardictjava.cwl
+    hints:
+      - class: 'sbg:AWSInstanceType'
+        value: c5.9xlarge
     in:
       input_tumor_bam: input_tumor_aligned
       input_tumor_name: input_tumor_name

--- a/tools/gatk_getpileupsummaries.cwl
+++ b/tools/gatk_getpileupsummaries.cwl
@@ -8,14 +8,14 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.1.0'
   - class: ResourceRequirement
-    ramMin: 2000
+    ramMin: $(inputs.max_memory)
     coresMin: 2
 baseCommand: [/gatk, GetPileupSummaries]
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      --java-options "-Xmx2000m"
+      --java-options "-Xmx${return Math.floor(inputs.max_memory/1.074-1)}m"
       -I $(inputs.aligned_reads.path)
       -V $(inputs.exac_common_vcf.path)
       -L $(inputs.interval_list.path)
@@ -27,6 +27,7 @@ inputs:
   reference: File
   interval_list: File
   exac_common_vcf: {type: File, secondaryFiles: [.tbi]}
+  max_memory: {type: int?, default: 2000, doc: "Maximum memory in MB for GATK GetPileupSummaries to use"}
 
 outputs:
   pileup_table:

--- a/tools/gatk_getpileupsummaries.cwl
+++ b/tools/gatk_getpileupsummaries.cwl
@@ -8,14 +8,14 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.1.0'
   - class: ResourceRequirement
-    ramMin: $(inputs.max_memory)
+    ramMin: ${ return inputs.max_memory * 1000 }
     coresMin: 2
 baseCommand: [/gatk, GetPileupSummaries]
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      --java-options "-Xmx${return Math.floor(inputs.max_memory/1.074-1)}m"
+      --java-options "-Xmx${return Math.floor(inputs.max_memory*1000/1.074-1)}m"
       -I $(inputs.aligned_reads.path)
       -V $(inputs.exac_common_vcf.path)
       -L $(inputs.interval_list.path)
@@ -27,7 +27,7 @@ inputs:
   reference: File
   interval_list: File
   exac_common_vcf: {type: File, secondaryFiles: [.tbi]}
-  max_memory: {type: int?, default: 2000, doc: "Maximum memory in MB for GATK GetPileupSummaries to use"}
+  max_memory: {type: int?, default: 20, doc: "Maximum memory in GB for GATK GetPileupSummaries to use"}
 
 outputs:
   pileup_table:

--- a/tools/gatk_getpileupsummaries.cwl
+++ b/tools/gatk_getpileupsummaries.cwl
@@ -27,7 +27,7 @@ inputs:
   reference: File
   interval_list: File
   exac_common_vcf: {type: File, secondaryFiles: [.tbi]}
-  max_memory: {type: int?, default: 20, doc: "Maximum memory in GB for GATK GetPileupSummaries to use"}
+  max_memory: {type: int?, default: 2, doc: "Maximum memory in GB for GATK GetPileupSummaries to use"}
 
 outputs:
   pileup_table:

--- a/tools/gatk_learnorientationbias.cwl
+++ b/tools/gatk_learnorientationbias.cwl
@@ -29,7 +29,7 @@ inputs:
       position: 1
   tool_name: string
   output_basename: string
-  max_memory: {type: int?, default: 40, doc: "Maximum memory in GB for GATK LearnReadOrientationModel"}
+  max_memory: {type: int?, default: 4, doc: "Maximum memory in GB for GATK LearnReadOrientationModel"}
 outputs:
   f1r2_bias:
     type: File

--- a/tools/gatk_learnorientationbias.cwl
+++ b/tools/gatk_learnorientationbias.cwl
@@ -8,14 +8,14 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.1.0'
   - class: ResourceRequirement
-    ramMin: $(inputs.max_memory)
+    ramMin: ${ return inputs.max_memory * 1000 }
     coresMin: 2
 baseCommand: [/gatk, LearnReadOrientationModel]
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      --java-options "-Xmx${return Math.floor(inputs.max_memory/1.074-1)}m"
+      --java-options "-Xmx${return Math.floor(inputs.max_memory*1000/1.074-1)}m"
       -O $(inputs.output_basename).$(inputs.tool_name).f1r2_bias.tar.gz 
 
 inputs:
@@ -29,7 +29,7 @@ inputs:
       position: 1
   tool_name: string
   output_basename: string
-  max_memory: {type: int?, default: 4000, doc: "Maximum memory for GATK LearnReadOrientationModel"}
+  max_memory: {type: int?, default: 40, doc: "Maximum memory in GB for GATK LearnReadOrientationModel"}
 outputs:
   f1r2_bias:
     type: File

--- a/tools/gatk_learnorientationbias.cwl
+++ b/tools/gatk_learnorientationbias.cwl
@@ -8,14 +8,14 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.1.0'
   - class: ResourceRequirement
-    ramMin: 4000
+    ramMin: $(inputs.max_memory)
     coresMin: 2
 baseCommand: [/gatk, LearnReadOrientationModel]
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      --java-options "-Xmx4000m"
+      --java-options "-Xmx${return Math.floor(inputs.max_memory/1.074-1)}m"
       -O $(inputs.output_basename).$(inputs.tool_name).f1r2_bias.tar.gz 
 
 inputs:
@@ -29,6 +29,7 @@ inputs:
       position: 1
   tool_name: string
   output_basename: string
+  max_memory: {type: int?, default: 4000, doc: "Maximum memory for GATK LearnReadOrientationModel"}
 outputs:
   f1r2_bias:
     type: File

--- a/tools/manta.cwl
+++ b/tools/manta.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: 10000
+    ramMin: $(inputs.ram)
     coresMin: $(inputs.cores)
   - class: DockerRequirement
     dockerPull: 'kfdrc/manta:1.4.0'
@@ -40,6 +40,7 @@ inputs:
     input_tumor_cram: {type: ["null", File], secondaryFiles: [.crai]}
     input_normal_cram: {type: ["null", File], secondaryFiles: [.crai]}
     cores: {type: ['null', int], default: 18}
+    ram: {type: int?, default: 10000, doc: "MB of RAM an instance must have to run the task"}
     output_basename: string
 outputs:
   output_sv:

--- a/tools/manta.cwl
+++ b/tools/manta.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: $(inputs.ram)
+    ramMin: ${ return inputs.ram * 1000 }
     coresMin: $(inputs.cores)
   - class: DockerRequirement
     dockerPull: 'kfdrc/manta:1.4.0'
@@ -40,7 +40,7 @@ inputs:
     input_tumor_cram: {type: ["null", File], secondaryFiles: [.crai]}
     input_normal_cram: {type: ["null", File], secondaryFiles: [.crai]}
     cores: {type: ['null', int], default: 18}
-    ram: {type: int?, default: 10000, doc: "MB of RAM an instance must have to run the task"}
+    ram: {type: int?, default: 10, doc: "GB of RAM an instance must have to run the task"}
     output_basename: string
 outputs:
   output_sv:

--- a/tools/manta.cwl
+++ b/tools/manta.cwl
@@ -18,7 +18,7 @@ arguments:
     shellQuote: false
     valueFrom: >-
       ${
-        var std = " --ref " + inputs.reference.path + " --callRegions " + inputs.hg38_strelka_bed.path + " --runDir=./ && ./runWorkflow.py -m local -j " + inputs.cores + " --quiet ";
+        var std = " --ref " + inputs.reference.path + " --callRegions " + inputs.hg38_strelka_bed.path + " --runDir=./ && ./runWorkflow.py -m local -j " + inputs.cores + " ";
         var mv = " && mv results/variants/";
         if (typeof inputs.input_tumor_cram === 'undefined' || inputs.input_tumor_cram === null){
           var mv_cmd = mv + "diploidSV.vcf.gz " +  inputs.output_basename + ".manta.diploidSV.vcf.gz" + mv + "diploidSV.vcf.gz.tbi " + inputs.output_basename + ".manta.diploidSV.vcf.gz.tbi" + mv + "candidateSmallIndels.vcf.gz " + inputs.output_basename + ".manta.candidateSmallIndels.vcf.gz" + mv + "candidateSmallIndels.vcf.gz.tbi " + inputs.output_basename + ".manta.candidateSmallIndels.vcf.gz.tbi";

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -255,8 +255,8 @@ inputs:
   combined_include_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed, i.e. for VarDict: FILTER=\"PASS\" && (INFO/STATUS=\"Germline\" | INFO/STATUS=\"StrongSomatic\")"}
   combined_exclude_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed"}
   use_manta_small_indels: {type: 'boolean?', default: false, doc: "Should the program use the small indels output from Manta in Strelka2 calling?"}
-  learnorientation_memory: {type: 'int?', doc: "GB of memory to allocate to GATK LearnReadOrientationModel; defaults to 40 (hard-capped)"}
-  getpileup_memory: {type: 'int?', doc: "GB of memory to allocate to GATK GetPileupSummaries; defaults to 20 (hard-capped)"}
+  learnorientation_memory: {type: 'int?', doc: "GB of memory to allocate to GATK LearnReadOrientationModel; defaults to 4 (hard-capped)"}
+  getpileup_memory: {type: 'int?', doc: "GB of memory to allocate to GATK GetPileupSummaries; defaults to 2 (hard-capped)"}
   manta_memory: {type: 'int?', doc: "GB of memory to allocate to Manta; defaults to 10 (soft-capped)"}
 
   # WGS only Fields

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -242,6 +242,8 @@ inputs:
   combined_include_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed, i.e. for VarDict: FILTER=\"PASS\" && (INFO/STATUS=\"Germline\" | INFO/STATUS=\"StrongSomatic\")"}
   combined_exclude_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed"}
   use_manta_small_indels: {type: 'boolean?', default: false, doc: "Should the program use the small indels output from Manta in Strelka2 calling?"}
+  learnorientation_memory: {type: 'int?', doc: "MB of memory to allocate to GATK learn orientation; defaults to 4000"}
+  getpileup_memory: {type: 'int?', doc: "MB of memory to allocate to GATK get pileup; defaults to 2000"}
 
   # WGS only Fields
   wgs_calling_interval_list: {type: File?, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
@@ -462,6 +464,8 @@ steps:
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename
+      learnorientation_memory: learnorientation_memory
+      getpileup_memory: getpileup_memory
       select_vars_mode: select_vars_mode
     out:
       [mutect2_filtered_stats, mutect2_filtered_vcf, mutect2_vep_vcf, mutect2_vep_tbi, mutect2_vep_maf]

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -161,6 +161,18 @@ doc: |-
       - `Variant Effect Predictor`: kfdrc/vep:r93_v2
       - `Manta`: kfdrc/manta:latest
       - `bcftools` and `vcftools`: kfdrc/bvcftools:latest
+  1. For highly complex samples, some tools have shown themselves to require memory allocation adjustments:
+     Manta, GATK LearnReadOrientationModel, GATK GetPileupSummaries, and Vardict. Optional inputs exist to expand the
+     memory allocation for these jobs: manta_memory, learnorientation_memory, getpileup_memory, and vardict_ram,
+     respectively. For the java tools (Vardict and GATK), these values represent limits on the memory that can
+     be used for the respective jobs. Tasks will go to these values and not exceed it. They may succeed or fail,
+     but they will not exceed the limit established. The memory allocations for these is hardcapped. The memory
+     allocation option for Manta, conversely, is a soft cap. The memory requested will be allocated for the job
+     on a particular machine but once the task is running on the machine it may exceed that requested value. For example,
+     if Manta's memory allocation is set to 10 GB it will have 10 GB allocated to it at task creation, but, if the
+     task ends up running on a machine with more memory available, the task may use it. The largest tasks run at KFDRC
+     have had this value set to 10 GB, but, when run on large machines, the tasks have been observed taking 60-70 GB of memory.
+     As such the option for Manta memory allocation is described as soft cap.
 
 requirements:
   - class: ScatterFeatureRequirement
@@ -221,7 +233,7 @@ inputs:
   min_theta2_frac: {type: 'float?', default: 0.01, doc: "Minimum fraction of genome with copy umber alterations.  Default is 0.05, recommend 0.01"}
   vardict_cpus: {type: 'int?', default: 9, doc: "Number of CPUs for Vardict to use"}
   vardict_min_vaf: {type: 'float?', default: 0.05, doc: "Min variant allele frequency for vardict to consider. Recommend 0.05"}
-  vardict_ram: {type: 'int?', default: 18, doc: "GB of RAM to allocate to Vardict"}
+  vardict_ram: {type: 'int?', default: 18, doc: "GB of RAM to allocate to Vardict (hard-capped)"}
   vep_ref_build: {type: 'string?', default: "GRCh38", doc: "Genome ref build used, should line up with cache"}
 
   # Optional with Multiple Defaults (handled in choose_defaults)
@@ -242,9 +254,9 @@ inputs:
   combined_include_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed, i.e. for VarDict: FILTER=\"PASS\" && (INFO/STATUS=\"Germline\" | INFO/STATUS=\"StrongSomatic\")"}
   combined_exclude_expression: {type: 'string?', doc: "Theta2 Purity value: Filter expression if vcf has non-PASS combined calls, use as-needed"}
   use_manta_small_indels: {type: 'boolean?', default: false, doc: "Should the program use the small indels output from Manta in Strelka2 calling?"}
-  learnorientation_memory: {type: 'int?', doc: "MB of memory to allocate to GATK learn orientation; defaults to 4000"}
-  getpileup_memory: {type: 'int?', doc: "MB of memory to allocate to GATK get pileup; defaults to 2000"}
-  manta_memory: {type: 'int?', doc: "MB of memory to allocate to Manta; defaults to 10000. Manta jobs take up all available memory on the instance. If jobs are running out of memory on a particular instance, make sure to add enough memory to take it to the next instance."}
+  learnorientation_memory: {type: 'int?', doc: "GB of memory to allocate to GATK LearnReadOrientationModel; defaults to 40 (hard-capped)"}
+  getpileup_memory: {type: 'int?', doc: "GB of memory to allocate to GATK GetPileupSummaries; defaults to 20 (hard-capped)"}
+  manta_memory: {type: 'int?', doc: "GB of memory to allocate to Manta; defaults to 10 (soft-capped)"}
 
   # WGS only Fields
   wgs_calling_interval_list: {type: File?, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -171,7 +171,7 @@ doc: |-
      on a particular machine but once the task is running on the machine it may exceed that requested value. For example,
      if Manta's memory allocation is set to 10 GB it will have 10 GB allocated to it at task creation, but, if the
      task ends up running on a machine with more memory available, the task may use it. Setting a value here for Manta
-     will not prevent Manta from taking more than that value. The memory usage is Manta is limited by the machine hardware.
+     will not prevent Manta from taking more than that value. The memory usage in Manta is limited by the machine hardware.
      As such the option for Manta memory allocation is described as soft cap. For more information on Manta resource
      usage see their [documentation](https://github.com/Illumina/manta/blob/master/docs/userGuide/README.md#runtime-hardware-requirements).
 

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -244,6 +244,7 @@ inputs:
   use_manta_small_indels: {type: 'boolean?', default: false, doc: "Should the program use the small indels output from Manta in Strelka2 calling?"}
   learnorientation_memory: {type: 'int?', doc: "MB of memory to allocate to GATK learn orientation; defaults to 4000"}
   getpileup_memory: {type: 'int?', doc: "MB of memory to allocate to GATK get pileup; defaults to 2000"}
+  manta_memory: {type: 'int?', doc: "MB of memory to allocate to Manta; defaults to 10000. Manta jobs take up all available memory on the instance. If jobs are running out of memory on a particular instance, make sure to add enough memory to take it to the next instance."}
 
   # WGS only Fields
   wgs_calling_interval_list: {type: File?, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
@@ -609,6 +610,7 @@ steps:
       input_normal_name: input_normal_name
       vep_cache: vep_cache
       output_basename: output_basename
+      manta_memory: manta_memory
       select_vars_mode: select_vars_mode
     out:
       [manta_prepass_vcf, manta_pass_vcf, manta_small_indels]
@@ -618,5 +620,3 @@ $namespaces:
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
     value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -170,9 +170,10 @@ doc: |-
      allocation option for Manta, conversely, is a soft cap. The memory requested will be allocated for the job
      on a particular machine but once the task is running on the machine it may exceed that requested value. For example,
      if Manta's memory allocation is set to 10 GB it will have 10 GB allocated to it at task creation, but, if the
-     task ends up running on a machine with more memory available, the task may use it. The largest tasks run at KFDRC
-     have had this value set to 10 GB, but, when run on large machines, the tasks have been observed taking 60-70 GB of memory.
-     As such the option for Manta memory allocation is described as soft cap.
+     task ends up running on a machine with more memory available, the task may use it. Setting a value here for Manta
+     will not prevent Manta from taking more than that value. The memory usage is Manta is limited by the machine hardware.
+     As such the option for Manta memory allocation is described as soft cap. For more information on Manta resource
+     usage see their [documentation](https://github.com/Illumina/manta/blob/master/docs/userGuide/README.md#runtime-hardware-requirements).
 
 requirements:
   - class: ScatterFeatureRequirement


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR contains various changes to combat memory issues running large samples through the workflow. The workflow now allows the user max memory for the following tools at task creation:
- GATK GetPileupSummaries
- GATK LearnReadOrientationModel

Additionally, the user can adjust the memory allocation for Manta. Manta works differently than the Java GATK tools in that it's max memory isn't capped by a java option. Manta's max memory simply indicates what allocation of a VM will be saved for its running. When the task actually runs it may go over that cap and cause memory issues.

Finally, in order to allow Manta to scale beyond the memory allocated by a c5.9xlarge VM we had to remove the instance type restriction from the top level workflow. This restriction was added back at the subworkflow/tool level where needed (Lancet, Mutect, and Vardict).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Cavatica test: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-zxjffmef-somatic-mutations-wgs-tumor/tasks/0d7c426b-0c88-4169-9479-6155d95a1ff8/
- [x] Tool passes cwltool validation

**Test Configuration**:
* Environment: Cavatica, cwltool 3.0.20200324120055
* Test files: See Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
