### PR TITLE
🧠 expose memory and cpu hooks

### DIFF
--- a/sub_workflows/kfdrc_manta_sub_wf.cwl
+++ b/sub_workflows/kfdrc_manta_sub_wf.cwl
@@ -41,6 +41,7 @@ inputs:
   vep_cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
   output_basename: string
   manta_memory: {type: int?}
+  manta_cores: {type: int?}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
 outputs:
@@ -56,6 +57,7 @@ steps:
       input_normal_cram: input_normal_aligned
       output_basename: output_basename
       ram: manta_memory
+      cores: manta_cores
       reference: indexed_reference_fasta
       hg38_strelka_bed: hg38_strelka_bed
     out: [output_sv, small_indels]

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -48,6 +48,7 @@ inputs:
   output_basename: string
   getpileup_memory: {type: int?}
   learnorientation_memory: {type: int?}
+  filtermutectcalls_memory: {type: int?}
   select_vars_mode: {type: ['null', {type: enum, name: select_vars_mode, symbols: ["gatk", "grep"]}], doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression", default: "gatk"}
 
 outputs:
@@ -119,6 +120,7 @@ steps:
       contamination_table: mutect2_filter_support/contamination_table
       segmentation_table: mutect2_filter_support/segmentation_table
       ob_priors: mutect2_filter_support/f1r2_bias
+      max_memory: filtermutectcalls_memory
     out: [stats_table, filtered_vcf]
 
   gatk_selectvariants:

--- a/tools/gatk_filtermutectcalls.cwl
+++ b/tools/gatk_filtermutectcalls.cwl
@@ -8,7 +8,7 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.1.0'
   - class: ResourceRequirement
-    ramMin: ${ return inputs.max_meory * 1000 }
+    ramMin: ${ return inputs.max_memory * 1000 }
     coresMin: 2
 baseCommand: [/gatk, FilterMutectCalls]
 arguments:

--- a/tools/gatk_filtermutectcalls.cwl
+++ b/tools/gatk_filtermutectcalls.cwl
@@ -8,14 +8,14 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'kfdrc/gatk:4.1.1.0'
   - class: ResourceRequirement
-    ramMin: 4000
+    ramMin: ${ return inputs.max_meory * 1000 }
     coresMin: 2
 baseCommand: [/gatk, FilterMutectCalls]
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      --java-options "-Xmx4000m"
+      --java-options "-Xmx${return Math.floor(inputs.max_memory*1000/1.074-1)}m"
       -V $(inputs.mutect_vcf.path)
       -O $(inputs.output_basename).mutect2_filtered.vcf.gz
       -R $(inputs.reference.path)
@@ -33,13 +33,14 @@ inputs:
   contamination_table: File
   segmentation_table: File
   ob_priors: File
-  
+  max_memory: {type: int?, default: 4, doc: "GB of memory to allocate to the task"}
+
 outputs:
   stats_table:
     type: File
     outputBinding:
       glob: '*.mutect2_filtered.txt'
-  
+
   filtered_vcf:
     type: File
     outputBinding:

--- a/workflow/kfdrc_production_manta_wf.cwl
+++ b/workflow/kfdrc_production_manta_wf.cwl
@@ -45,6 +45,8 @@ inputs:
 
   # Optional with One Default
   select_vars_mode: { type: ['null', { type: enum, name: select_vars_mode, symbols: ["gatk", "grep"] }], default: "gatk", doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression" }
+  manta_memory: {type: 'int?', doc: "GB of memory to allocate to Manta; defaults to 10 (soft-capped)"}
+  manta_cores: {type: 'int?', doc: "Number of cores to allocate to Manta; defaults to 18"}
 
 outputs:
   manta_pass_vcf: { type: File, outputSource: run_manta/manta_pass_vcf }
@@ -79,6 +81,8 @@ steps:
       input_normal_name: input_normal_name
       vep_cache: vep_cache
       output_basename: output_basename
+      manta_memory: manta_memory
+      manta_cores: manta_cores
       select_vars_mode: select_vars_mode
     out:
       [manta_prepass_vcf, manta_pass_vcf, manta_small_indels]

--- a/workflow/kfdrc_production_mutect2_wf.cwl
+++ b/workflow/kfdrc_production_mutect2_wf.cwl
@@ -49,6 +49,9 @@ inputs:
   # Optional with One Default
   select_vars_mode: { type: ['null', { type: enum, name: select_vars_mode, symbols: ["gatk", "grep"] }], default: "gatk", doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression" }
   vep_ref_build: { type: 'string?', default: "GRCh38", doc: "Genome ref build used, should line up with cache" }
+  learnorientation_memory: {type: 'int?', doc: "GB of memory to allocate to GATK LearnReadOrientationModel; defaults to 4 (hard-capped)"}
+  getpileup_memory: {type: 'int?', doc: "GB of memory to allocate to GATK GetPileupSummaries; defaults to 2 (hard-capped)"}
+  filtermutectcalls_memory: {type: 'int?', doc: "GB of memory to allocate to GATK FilterMutectCalls; defaults to 4 (hard-capped)"}
 
   # Optional with Multiple Defaults (handled in choose_defaults)
   exome_flag: { type: 'string?', doc: "Whether to run in exome mode for callers. Y for WXS, N for WGS" }
@@ -141,6 +144,9 @@ steps:
       exome_flag: choose_defaults/out_exome_flag
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
+      learnorientation_memory: learnorientation_memory
+      getpileup_memory: getpileup_memory
+      filtermutectcalls_memory: filtermutectcalls_memory
       output_basename: output_basename
       select_vars_mode: select_vars_mode
     out:

--- a/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
+++ b/workflow/kfdrc_production_somatic_variant_cnv_wf.cwl
@@ -257,7 +257,9 @@ inputs:
   use_manta_small_indels: {type: 'boolean?', default: false, doc: "Should the program use the small indels output from Manta in Strelka2 calling?"}
   learnorientation_memory: {type: 'int?', doc: "GB of memory to allocate to GATK LearnReadOrientationModel; defaults to 4 (hard-capped)"}
   getpileup_memory: {type: 'int?', doc: "GB of memory to allocate to GATK GetPileupSummaries; defaults to 2 (hard-capped)"}
+  filtermutectcalls_memory: {type: 'int?', doc: "GB of memory to allocate to GATK FilterMutectCalls; defaults to 4 (hard-capped)"}
   manta_memory: {type: 'int?', doc: "GB of memory to allocate to Manta; defaults to 10 (soft-capped)"}
+  manta_cores: {type: 'int?', doc: "Number of cores to allocate to Manta; defaults to 18"}
 
   # WGS only Fields
   wgs_calling_interval_list: {type: File?, doc: "GATK intervals list-style, or bed file.  Recommend canocical chromosomes with N regions removed"}
@@ -480,6 +482,7 @@ steps:
       output_basename: output_basename
       learnorientation_memory: learnorientation_memory
       getpileup_memory: getpileup_memory
+      filtermutectcalls_memory: filtermutectcalls_memory
       select_vars_mode: select_vars_mode
     out:
       [mutect2_filtered_stats, mutect2_filtered_vcf, mutect2_vep_vcf, mutect2_vep_tbi, mutect2_vep_maf]
@@ -624,6 +627,7 @@ steps:
       vep_cache: vep_cache
       output_basename: output_basename
       manta_memory: manta_memory
+      manta_cores: manta_cores
       select_vars_mode: select_vars_mode
     out:
       [manta_prepass_vcf, manta_pass_vcf, manta_small_indels]


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

- memory changes for the somatic workflow now exposing gatk FilterMutectCalls.
- bringing the standalone workflows up to date with the changes to the main workflow.
- expose cpu option for manta as lowering cores could potentially cap memory usage in extreme cases

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] @bmennis is testing here: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-zxjffmef-somatic-mutations-wgs-tumor/tasks/#q

**Test Configuration**:
* Environment: Cavatica
* Test files: see revision 5 tasks

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
