### PR TITLE
🐛 quote python -c script

### DIFF
--- a/tools/ubuntu_ratio2seg.cwl
+++ b/tools/ubuntu_ratio2seg.cwl
@@ -11,6 +11,7 @@ requirements:
 baseCommand: [python, -c]
 arguments:
   - position: 0
+    shellQuote: true
     valueFrom: |
 
         import math

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -741,5 +741,5 @@ sbg:categories:
 - VCF
 - VEP
 sbg:links:
-- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v2.2.0'
+- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v2.2.1'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Sets shellQuote to true in ubuntu_ratio2seg.cwl python -c argument. This block is supposed to be quoted as python -c takes a string input. Cavatica will default shellQuote to false and cause this tool to fail.

Closes https://github.com/d3b-center/bixu-tracker/issues/833

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Cavatica test: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/20eeaf68-7513-474b-986f-a0e82e4597aa/
- [x] Tool passes cwltool validation though it would probably fail as it has tabs and whatnot (issue for another time)

**Test Configuration**:
* Environment: Cavatica, cwltool 3.0.20200807132242
* Test files: See Cavatica test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings