### PR TITLE
🏇 Scaled back some hints for per-tool wfs. Too aggressive!

### DIFF
--- a/workflow/kfdrc_production_cnvkit_wf.cwl
+++ b/workflow/kfdrc_production_cnvkit_wf.cwl
@@ -144,6 +144,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 4

--- a/workflow/kfdrc_production_controlfreec_wf.cwl
+++ b/workflow/kfdrc_production_controlfreec_wf.cwl
@@ -155,6 +155,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 4

--- a/workflow/kfdrc_production_lancet_wf.cwl
+++ b/workflow/kfdrc_production_lancet_wf.cwl
@@ -182,6 +182,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 4

--- a/workflow/kfdrc_production_manta_wf.cwl
+++ b/workflow/kfdrc_production_manta_wf.cwl
@@ -91,6 +91,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 2

--- a/workflow/kfdrc_production_mutect2_wf.cwl
+++ b/workflow/kfdrc_production_mutect2_wf.cwl
@@ -156,6 +156,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 4

--- a/workflow/kfdrc_production_strekla2_wf.cwl
+++ b/workflow/kfdrc_production_strekla2_wf.cwl
@@ -106,6 +106,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 2

--- a/workflow/kfdrc_production_theta2_wf.cwl
+++ b/workflow/kfdrc_production_theta2_wf.cwl
@@ -45,6 +45,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 2

--- a/workflow/kfdrc_production_vardict_wf.cwl
+++ b/workflow/kfdrc_production_vardict_wf.cwl
@@ -163,6 +163,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 4


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

The per-tool workflows inherited the resource requirements of the production workflow. However, at this level it leads to lots of unused cores and memory and increased calls. I've removed the instance hint at the wf level and reduced parallel instance counts to scale this back a bit. Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
