### PR TITLE
🛂 ControlFreeC I/O Port Openings

### DIFF
--- a/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
+++ b/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
@@ -27,6 +27,7 @@ inputs:
 
 outputs:
   ctrlfreec_pval: {type: File, outputSource: rename_outputs/ctrlfreec_pval}
+  ctrlfreec_cnvs: {type: File, outputSource: rename_outputs/ctrlfreec_cnvs}
   ctrlfreec_config: {type: File, outputSource: rename_outputs/ctrlfreec_config}
   ctrlfreec_pngs: {type: 'File[]', outputSource: rename_outputs/ctrlfreec_pngs}
   ctrlfreec_bam_ratio: {type: File, outputSource: rename_outputs/ctrlfreec_bam_ratio}
@@ -75,15 +76,15 @@ steps:
       coeff_var: coeff_var
       sex: cfree_sex
       contamination_adjustment: contamination_adjustment
-    out: [cnvs_pvalue, config_script, pngs, ratio, sample_BAF, info_txt]
+    out: [cnvs, cnvs_pvalue, config_script, pngs, ratio, sample_BAF, info_txt]
 
   rename_outputs:
     run: ../tools/ubuntu_rename_outputs.cwl
     in:
-      input_files: [control_free_c/cnvs_pvalue, control_free_c/config_script, control_free_c/ratio, control_free_c/sample_BAF, control_free_c/info_txt]
+      input_files: [control_free_c/cnvs, control_free_c/cnvs_pvalue, control_free_c/config_script, control_free_c/ratio, control_free_c/sample_BAF, control_free_c/info_txt]
       input_pngs: control_free_c/pngs
       output_basename: output_basename
-    out: [ctrlfreec_pval, ctrlfreec_config, ctrlfreec_pngs, ctrlfreec_bam_ratio, ctrlfreec_baf, ctrlfreec_info]
+    out: [ctrlfreec_cnvs, ctrlfreec_pval, ctrlfreec_config, ctrlfreec_pngs, ctrlfreec_bam_ratio, ctrlfreec_baf, ctrlfreec_info]
   
   convert_ratio_to_seg:
     run: ../tools/ubuntu_ratio2seg.cwl

--- a/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
+++ b/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
@@ -14,6 +14,10 @@ inputs:
   threads: {type: int, doc: "Number of threads to run controlfreec.  Going above 16 is not recommended, there is no apparent added value"}
   output_basename: string
   ploidy: {type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try"}
+  mate_copynumber_file_control: {type: File?, doc: "Normal cpn file from previous run. If used, will override bam use"}
+  mate_copynumber_file_sample: {type: File?, doc: "Tumor cpn file from previous run. If used, will override bam use"}
+  gem_mappability_file: {type: File?, doc: "GEM mappability file to make read count adjustments with"}
+  min_subclone_presence: {type: float?, doc: "Use if you want to detect sublones. Recommend 0.2 for WGS, 0.3 for WXS"}
   mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
   mate_orientation_control: {type: ['null', {type: enum, name: mate_orientation_control, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
   capture_regions: {type: ['null', File], doc: "If not WGS, provide "}
@@ -61,6 +65,10 @@ steps:
   control_free_c: 
     run: ../tools/control-freec-11-6-sbg.cwl
     in: 
+      mate_copynumber_file_control: mate_copynumber_file_control
+      mate_copynumber_file_sample: mate_copynumber_file_sample
+      gem_mappability_file: gem_mappability_file
+      min_subclone_presence: min_subclone_presence
       mate_file_sample: input_tumor_aligned
       mate_orientation_sample: mate_orientation_sample
       mini_pileup_sample: controlfreec_tumor_mini_pileup/pileup

--- a/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
+++ b/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
@@ -26,8 +26,8 @@ inputs:
   cfree_sex: {type: ['null', {type: enum, name: sex, symbols: ["XX", "XY"] }], doc: "If known, XX for female, XY for male"}
 
 outputs:
-  ctrlfreec_pval: {type: File, outputSource: rename_outputs/ctrlfreec_pval}
   ctrlfreec_cnvs: {type: File, outputSource: rename_outputs/ctrlfreec_cnvs}
+  ctrlfreec_pval: {type: File, outputSource: rename_outputs/ctrlfreec_pval}
   ctrlfreec_config: {type: File, outputSource: rename_outputs/ctrlfreec_config}
   ctrlfreec_pngs: {type: 'File[]', outputSource: rename_outputs/ctrlfreec_pngs}
   ctrlfreec_bam_ratio: {type: File, outputSource: rename_outputs/ctrlfreec_bam_ratio}

--- a/tools/ubuntu_rename_outputs.cwl
+++ b/tools/ubuntu_rename_outputs.cwl
@@ -56,7 +56,7 @@ outputs:
     type: File?
     outputBinding:
       glob: '*.BAF.txt'
-  ctrlfreec_cnv:
+  ctrlfreec_cnvs:
     type: File
     outputBinding:
       glob: '*.CNVs'

--- a/workflow/kfdrc_production_controlfreec_wf.cwl
+++ b/workflow/kfdrc_production_controlfreec_wf.cwl
@@ -37,6 +37,11 @@ inputs:
         }
       }
     doc: "normal BAM or CRAM"
+  
+  mate_copynumber_file_control: {type: File?, doc: "Normal cpn file from previous run. If used, will override bam use"}
+  mate_copynumber_file_sample: {type: File?, doc: "Tumor cpn file from previous run. If used, will override bam use"}
+  gem_mappability_file: {type: File?, doc: "GEM mappability file to make read count adjustments with"}
+  min_subclone_presence: {type: float?, doc: "Use if you want to detect sublones. Recommend 0.2 for WGS, 0.3 for WXS"}
   cfree_chr_len: { type: File, doc: "file with chromosome lengths" }
   cfree_ploidy: { type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try" }
   output_basename: { type: string, doc: "String value to use as basename for outputs" }
@@ -133,6 +138,10 @@ steps:
   run_controlfreec:
     run: ../sub_workflows/kfdrc_controlfreec_sub_wf.cwl
     in:
+      mate_copynumber_file_control: mate_copynumber_file_control
+      mate_copynumber_file_sample: mate_copynumber_file_sample
+      gem_mappability_file: gem_mappability_file
+      min_subclone_presence: min_subclone_presence
       input_tumor_aligned: samtools_cram2bam_plus_calmd_tumor/bam_file
       input_tumor_name: input_tumor_name
       input_normal_aligned: samtools_cram2bam_plus_calmd_normal/bam_file
@@ -156,6 +165,4 @@ $namespaces:
   sbg: https://sevenbridges.com
 hints:
   - class: 'sbg:maxNumberOfParallelInstances'
-    value: 6
-  - class: 'sbg:AWSInstanceType'
-    value: c5.9xlarge
+    value: 4

--- a/workflow/kfdrc_production_controlfreec_wf.cwl
+++ b/workflow/kfdrc_production_controlfreec_wf.cwl
@@ -61,6 +61,7 @@ inputs:
   unpadded_capture_regions: { type: 'File?', doc: "Capture regions with NO padding for cnv calling" }
 
 outputs:
+  ctrlfreec_cnvs: {type: File, outputSource: run_controlfreec/ctrlfreec_cnvs}
   ctrlfreec_pval: { type: File, outputSource: run_controlfreec/ctrlfreec_pval }
   ctrlfreec_config: { type: File, outputSource: run_controlfreec/ctrlfreec_config }
   ctrlfreec_pngs: { type: 'File[]', outputSource: run_controlfreec/ctrlfreec_pngs }
@@ -149,7 +150,7 @@ steps:
       contamination_adjustment: cfree_contamination_adjustment
       cfree_sex: cfree_sex
     out:
-      [ctrlfreec_pval, ctrlfreec_config, ctrlfreec_pngs, ctrlfreec_bam_ratio, ctrlfreec_bam_seg, ctrlfreec_baf, ctrlfreec_info]
+      [ctrlfreec_cnvs, ctrlfreec_pval, ctrlfreec_config, ctrlfreec_pngs, ctrlfreec_bam_ratio, ctrlfreec_bam_seg, ctrlfreec_baf, ctrlfreec_info]
 
 $namespaces:
   sbg: https://sevenbridges.com


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Updated standalone ControlFreeC app to accept a `.mappability` file created using gem, `.cpn` files for fast re-processing of previous results, and `min_subclone_presence` inputs to allow for ControlFreeC to calculate possible subclones

Related to https://github.com/d3b-center/bixu-tracker/issues/848

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested in prod, like a boss: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-8y99qzjj/tasks/#q?search=kfdrc-production-controlfreec-wf%20TEST&page=1


**Test Configuration**:
* Environment: Cavatica
* Test files: cram/.cpn inputs

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
