### PR TITLE
🎉 Add new VEP tool for future somatic processing

### DIFF
--- a/dev/output_vcf_pick.py
+++ b/dev/output_vcf_pick.py
@@ -1,0 +1,27 @@
+""" 
+Quick script to output vcf with PICK only hits
+"""
+
+import argparse
+import pysam
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--input_vcf', help='VCF file to subset')
+parser.add_argument('--csq_field', help='Key used to find consenquences, usually CSQ or ANN')
+args = parser.parse_args()
+
+in_vcf = pysam.VariantFile(args.input_vcf, threads=8)
+csq_fields = in_vcf.header.info['CSQ'].description.replace("Consequence annotations from Ensembl VEP. Format: ", "").split("|")
+
+# get index of PICK field
+p_idx = csq_fields.index("PICK")
+
+print("chrom\tpos\tref\talt\tpicked_ct\tpicked_csq_csv")
+
+for record in in_vcf.fetch():
+    picked_csqs = []
+    for csq in record.info['CSQ']:
+        info = csq.split("|")
+        if info[p_idx] == '1':
+            picked_csqs.append(csq)
+    print("\t".join([record.contig, str(record.pos), record.ref, record.alts[0], str(len(picked_csqs)), ",".join(picked_csqs)]))

--- a/dev/vep_somatic_annotate_r93.cwl
+++ b/dev/vep_somatic_annotate_r93.cwl
@@ -73,13 +73,13 @@ arguments:
       && /ensembl-vep-release-93.7/htslib/tabix $(inputs.output_basename).$(inputs.tool_name).PASS.vep.vcf.gz
 
 inputs:
-  reference: {type: File,  secondaryFiles: [.fai], label: Fasta genome assembly with index}
+  reference: {type: File,  secondaryFiles: [.fai], doc: "Fasta genome assembly with index"}
   input_vcf: {type: File, secondaryFiles: [.tbi]}
   species: {type: string?, default: "homo_sapiens"}
   merged: {type: boolean?, default: false}
   output_basename: string
   tool_name: string
-  cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
   cache_version: {type: int?, doc: "Version being used, should match build version", default: 93}
   ref_build: {type: string?, doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
 

--- a/dev/vep_somatic_annotate_r93.cwl
+++ b/dev/vep_somatic_annotate_r93.cwl
@@ -9,7 +9,7 @@ requirements:
     coresMin: 16
   - class: DockerRequirement
     dockerPull: 'migbro/vep:r93.7'
-baseCommand: [mkdir ]
+baseCommand: [mkdir]
 arguments:
   - position: 1
     shellQuote: false

--- a/dev/vep_somatic_annotate_r93.cwl
+++ b/dev/vep_somatic_annotate_r93.cwl
@@ -43,7 +43,14 @@ arguments:
       --no_escape
       --no_progress
       --no_stats
-      --merged
+      ${
+        if(inputs.merged){
+          return "--merged";
+        }
+        else{
+          return "";
+        }
+      }
       --numbers
       --offline
       --output_file $(inputs.output_basename).$(inputs.tool_name).PASS.vep.vcf
@@ -69,6 +76,7 @@ inputs:
   reference: {type: File,  secondaryFiles: [.fai], label: Fasta genome assembly with index}
   input_vcf: {type: File, secondaryFiles: [.tbi]}
   species: {type: string?, default: "homo_sapiens"}
+  merged: {type: boolean?, default: false}
   output_basename: string
   tool_name: string
   cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}

--- a/dev/vep_somatic_annotate_r93.cwl
+++ b/dev/vep_somatic_annotate_r93.cwl
@@ -1,0 +1,87 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: kfdrc-vep-somatic-annotate
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    ramMin: 24000
+    coresMin: 16
+  - class: DockerRequirement
+    dockerPull: 'vep:r93.7'
+baseCommand: [mkdir ]
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.species)
+      && tar -I pigz -xf $(inputs.cache.path) -C $(inputs.species)
+      && perl /ensembl-vep-release-93.7/vep
+      --af
+      --af_1kg
+      --af_esp
+      --af_gnomad
+      --allele_number
+      --assembly $(inputs.ref_build)
+      --biotype
+      --buffer_size 10000
+      --cache
+      --cache_version $(inputs.cache_version)
+      --canonical
+      --ccds
+      --check_existing
+      --dir_cache $(inputs.species)
+      --domains
+      --failed 1
+      --fasta $(inputs.reference.path)
+      --flag_pick_allele
+      --fork 16
+      --format vcf
+      --gene_phenotype
+      --hgvs
+      --input_file $(inputs.input_vcf.path)
+      --no_escape
+      --no_progress
+      --no_stats
+      --merged
+      --numbers
+      --offline
+      --output_file $(inputs.output_basename).$(inputs.tool_name).PASS.vep.vcf
+      --pick_order canonical,tsl,biotype,rank,ccds,length
+      --polyphen b
+      --protein
+      --pubmed
+      --regulatory
+      --shift_hgvs 1
+      --sift b
+      --species $(inputs.species)
+      --symbol
+      --total_length
+      --tsl
+      --uniprot
+      --variant_class
+      --vcf
+      --xref_refseq
+      && /ensembl-vep-release-93.7/htslib/bgzip $(inputs.output_basename).$(inputs.tool_name).PASS.vep.vcf
+      && /ensembl-vep-release-93.7/htslib/tabix $(inputs.output_basename).$(inputs.tool_name).PASS.vep.vcf.gz
+
+inputs:
+  reference: {type: File,  secondaryFiles: [.fai], label: Fasta genome assembly with index}
+  input_vcf: {type: File, secondaryFiles: [.tbi]}
+  species: {type: string?, default: "homo_sapiens"}
+  output_basename: string
+  tool_name: string
+  cache: {type: File, label: tar gzipped cache from ensembl/local converted cache}
+  cache_version: {type: int?, doc: "Version being used, should match build version", default: 93}
+  ref_build: {type: string?, doc: "Genome ref build used, should line up with cache.", default: "GRCh38" }
+
+
+outputs:
+  output_vcf:
+    type: File
+    outputBinding:
+      glob: '*.vcf.gz'
+  output_tbi:
+    type: File  
+    outputBinding:
+      glob: '*.vcf.gz.tbi'

--- a/dev/vep_somatic_annotate_r93.cwl
+++ b/dev/vep_somatic_annotate_r93.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: 24000
     coresMin: 16
   - class: DockerRequirement
-    dockerPull: 'vep:r93.7'
+    dockerPull: 'migbro/vep:r93.7'
 baseCommand: [mkdir ]
 arguments:
   - position: 1


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This is part of the D3b somatic germline masking and annotation update effort. This tool runs with n updated docker containing pigz and dropping the mskcc vcf2maf tool. `dockerPull` will be updated in next PR, once it is part of vcf2maf/consensus workflow and dockerfile is approved.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] cwltool version `3.0.20210124104916`, provide any vcf and [use this ensembl-only](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/files/6023ff13b9ad204393672f4d/) cache or [or this merged cache](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/files/60240879fb574c13b655e8af/) when merged flag is true. Reference [file](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/files/5b27fd8fec70495356f7da6a/)
- [x] Cavatica task [ensembl only input](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/ddd47fc3-4585-4c5b-b8c8-63f73396b0cb/), results should be nearly identical (sometimes order of dbSNP IDs is switched) to vcf output from this [task](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/c146b686-2ec2-4534-9880-bea3209488c4/)
- [x] Cavatica task [merged cache input](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/d3dc84ef-0bc2-47e8-8d3f-b9a382321bdf/)

**Test Configuration**:
See above

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
