### PR TITLE
🎭 Germline masking tools

### DIFF
--- a/tools/bcftools_annotate.cwl
+++ b/tools/bcftools_annotate.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.0
 class: CommandLineTool
-id: bcbio_annotate_vcf
+id: bcftools_annotate_vcf
 doc: "Simple tool to annotate a vcf using bcftools and an annotation vcf"
 requirements:
   - class: ShellCommandRequirement

--- a/tools/bcftools_annotate.cwl
+++ b/tools/bcftools_annotate.cwl
@@ -27,7 +27,7 @@ inputs:
     input_vcf: {type: File, secondaryFiles: ['.tbi']}
     annotation_vcf: {type: File, secondaryFiles: ['.tbi'], doc: "bgzipped annotation vcf file"}
     columns: {type: string, doc: "csv string of columns from annotation to port into the input vcf, i.e INFO/AF"}
-    threads: {type: int, doc: "Number of compression/decompression threads", default: 4}
+    threads: {type: int?, doc: "Number of compression/decompression threads", default: 4}
     output_basename: string
     tool_name: string
 

--- a/tools/bcftools_annotate.cwl
+++ b/tools/bcftools_annotate.cwl
@@ -1,0 +1,39 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: bcbio_annotate_vcf
+doc: "Simple tool to annotate a vcf using bcftools and an annotation vcf"
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    ramMin: 8000
+    coresMin: 4
+  - class: DockerRequirement
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/vcfutils:latest'
+
+baseCommand: [bcftools, annotate]
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      --annotations $(inputs.annotation_vcf.path)
+      --columns $(inputs.columns)
+      -o $(inputs.output_basename).$(inputs.tool_name).bcf_annotated.vcf.gz
+      -O z
+      --threads $(inputs.threads)
+      $(inputs.input_vcf.path)
+      && tabix $(inputs.output_basename).$(inputs.tool_name).bcf_annotated.vcf.gz
+inputs:
+    input_vcf: {type: File, secondaryFiles: ['.tbi']}
+    annotation_vcf: {type: File, secondaryFiles: ['.tbi'], doc: "bgzipped annotation vcf file"}
+    columns: {type: string, doc: "csv string of columns from annotation to port into the input vcf, i.e INFO/AF"}
+    threads: {type: int, doc: "Number of compression/decompression threads", default: 4}
+    output_basename: string
+    tool_name: string
+
+outputs:
+  bcftools_annotated_vcf:
+    type: File
+    outputBinding:
+      glob: '*.vcf.gz'
+    secondaryFiles: ['.tbi']

--- a/tools/gatk_variant_filter.cwl
+++ b/tools/gatk_variant_filter.cwl
@@ -19,28 +19,18 @@ arguments:
       -R $(inputs.reference.path)
       -V $(inputs.input_vcf.path)
       -O $(inputs.output_basename).$(inputs.tool_name).gatk.soft_filtered.vcf.gz
-      --filter-name "NORM_HIGH" --filter-expression 'vc.getGenotype("BS_9H6Z0MEG").getAD().1 >0' --filter-name GNOMAD_AF_HIGH --filter-expression "AF > 0.01"
+      ${
+        var args = "";
+        for (var i = 0; i < inputs.filter_name.length; i++){
+          args += "--filter-name " + inputs.filter_name[0] + " --filter-expression " + inputs.filter_expression[i] + " ";
+        }
+      }
+
 inputs:
     input_vcf: {type: File, secondaryFiles: ['.tbi']}
     reference: {type: File, secondaryFiles: [^.dict]}
-    filter_name: 
-      type:
-        type: array
-        items: string
-        inputBinding:
-          prefix: --filter-name
-      inputBinding:
-        position: 1
-      doc: "Array of names for each filter tag to add"
-    filter_expression:
-      type:
-        type: array
-        items: string
-        inputBinding:
-          prefix: --filter-expression
-      inputBinding:
-        position: 1
-      doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for clues"
+    filter_name: {type: 'string[]', doc: "Array of names for each filter tag to add"}
+    filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for clues"}
     threads: {type: int, doc: "Number of compression/decompression threads", default: 4}
     output_basename: string
     tool_name: string

--- a/tools/gatk_variant_filter.cwl
+++ b/tools/gatk_variant_filter.cwl
@@ -1,0 +1,53 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: gatk_variantfilter_vcf
+doc: "Simple tool add a FILTER tag based on criteria"
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    ramMin: 8000
+    coresMin: 4
+  - class: DockerRequirement
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.1.0'
+
+baseCommand: [/gatk, VariantFiltration]
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      -R $(inputs.reference.path)
+      -V $(inputs.input_vcf.path)
+      -O $(inputs.output_basename).$(inputs.tool_name).gatk.soft_filtered.vcf.gz
+      --filter-name "NORM_HIGH" --filter-expression 'vc.getGenotype("BS_9H6Z0MEG").getAD().1 >0' --filter-name GNOMAD_AF_HIGH --filter-expression "AF > 0.01"
+inputs:
+    input_vcf: {type: File, secondaryFiles: ['.tbi']}
+    reference: {type: File, secondaryFiles: [^.dict]}
+    filter_name: 
+      type:
+        type: array
+        items: string
+        inputBinding:
+          prefix: --filter-name
+      inputBinding:
+        position: 1
+      doc: "Array of names for each filter tag to add"
+    filter_expression:
+      type:
+        type: array
+        items: string
+        inputBinding:
+          prefix: --filter-expression
+      inputBinding:
+        position: 1
+      doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for clues"
+    threads: {type: int, doc: "Number of compression/decompression threads", default: 4}
+    output_basename: string
+    tool_name: string
+
+outputs:
+  gatk_soft_filtered_vcf:
+    type: File
+    outputBinding:
+      glob: '*.vcf.gz'
+    secondaryFiles: ['.tbi']

--- a/tools/gatk_variant_filter.cwl
+++ b/tools/gatk_variant_filter.cwl
@@ -22,13 +22,14 @@ arguments:
       ${
         var args = "";
         for (var i = 0; i < inputs.filter_name.length; i++){
-          args += "--filter-name " + inputs.filter_name[0] + " --filter-expression " + inputs.filter_expression[i] + " ";
+          args += "--filter-name \"" + inputs.filter_name[i] + "\" --filter-expression \"" + inputs.filter_expression[i] + "\" ";
         }
+        return args
       }
 
 inputs:
     input_vcf: {type: File, secondaryFiles: ['.tbi']}
-    reference: {type: File, secondaryFiles: [^.dict]}
+    reference: {type: File, secondaryFiles: [^.dict, .fai]}
     filter_name: {type: 'string[]', doc: "Array of names for each filter tag to add"}
     filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for clues"}
     threads: {type: int, doc: "Number of compression/decompression threads", default: 4}

--- a/tools/gatk_variant_filter.cwl
+++ b/tools/gatk_variant_filter.cwl
@@ -32,7 +32,7 @@ inputs:
     reference: {type: File, secondaryFiles: [^.dict, .fai]}
     filter_name: {type: 'string[]', doc: "Array of names for each filter tag to add"}
     filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for clues"}
-    threads: {type: int, doc: "Number of compression/decompression threads", default: 4}
+    threads: {type: int?, doc: "Number of compression/decompression threads", default: 4}
     output_basename: string
     tool_name: string
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR adds a tool to annotate fairly generically a vcf file using another vcf reference. It also adds a tool to fairly generically add a `FILTER` tag field for when conditions are met. These will be the new components to add to somatic caller workflows for public releases. 

Addresses # https://github.com/d3b-center/bixu-tracker/issues/818

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update - will add to readme when workflows are updated

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] 1. cwltool: `python3 -m cwltool --cachedir ./ --outdir bcf_annot ~/tools/kf-somatic-workflow/tools/bcftools_annotate.cwl --annotation_vcf ~/volume/mask_dev/local_input_check/af-only-gnomad.hg38.vcf.gz --columns "INFO/AF" --input_vcf BS_M5FM63EB.consensus.PASS.vep.vcf.gz --output_basename bcf_tools_annot --tool_name consensus 2> bcf.errs > bcf.out`
- [ ] 1. Cavatica: https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/df6cdeab-b612-4d16-841a-e3d98ce488b8/
- [ ] 2. cwltool (used output from bcftools annotate as vcf input): `python3 -m cwltool --cachedir ./ --outdir gatk_soft ~/tools/kf-somatic-workflow/tools/gatk_variant_filter.cwl --input_vcf bcf_annot/bcf_tools_annot.consensus.bcf_annotated.vcf.gz --output_basename gatk_filt --reference ~/volume/mask_dev/Homo_sapiens_assembly38.fasta --tool_name consensus --filter_name NORM_HIGH --filter_expression "vc.getGenotype('BS_9H6Z0MEG').getAD().1 >0" --filter_name GNOMAD_AF_HIGH --filter_expression  "AF > 0.01" 2> gatk.errs > gatk.out &`
- [ ] 2. Cavatica (output from bcftools annotate cavatica task used as input for vcf): https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/b8be030a-e828-4693-9728-97903cedaa87/

**Test Configuration**:
* Environment:
* Test files:
  1. [`annotation_vcf`](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/files/5caf6dbde4b07ea21e2c97b2/) (tabix index or get from project), [`input_vcf`](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/files/6037fe453843333f57ee1153/)
  2.  `input_vcf`: from test 1, [`reference`](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/files/5b27fd8fec70495356f7da6a/): get or create `.fai` and `^.dict` files

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
