### PR TITLE
place output in . and fix output basename

### DIFF
--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -529,17 +529,21 @@ def build_output_record(single_caller_variants, output_vcf, sample_names, hotspo
 
     return output_record
 
-def build_output_name(inpath, outbase):
+def build_output_name(inpath, output_basename):
     """Builds an VCF.GZ output filename based on the input (VCF/VCF.GZ) name
-           and given output basename
+       The filename will be the input filename with '.consensus' inserted before '.vcf.gz'
+           and a change of basename to the provided value
+
        Args:
            inpath (str): Path to the input VCF(.GZ) file
-           outbase (str): Given output basename string
+           output_basename (str): Used as first element of output filename in place of 
+               first element of name of inpath filename
        Return:
            str: Filename in the format <output_basename>.<input_nameroot>.consensus.vcf.gz
     """
     basename_split = os.path.split(inpath)[-1].split('.')
-    return '.'.join([outbase, basename_split[0] + '.consensus.vcf.gz'])
+    output_fields = [output_basename] + basename_split[1:-2] + ['consensus'] + basename_split[-2:]
+    return '.'.join(output_fields)
 
 if __name__ == "__main__":
 
@@ -569,10 +573,9 @@ if __name__ == "__main__":
     vardict_vcf = pysam.VariantFile(args.vardict_vcf, 'r')
 
     # Create output vcf
-    base_dir = os.path.split(os.path.abspath(args.strelka2_vcf))[0]
+    base_dir = os.getcwd()
     output_vcf_name = build_output_name(args.vardict_vcf, args.output_basename)
     output_vcf_path = os.path.join(base_dir, output_vcf_name)
-    # print(output_vcf_path)
     output_vcf = pysam.VariantFile(output_vcf_path, 'w')
     write_output_header(output_vcf, strelka2_vcf.header.samples,
                         strelka2_vcf.header.contigs.values(), args.hotspot_source)


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This is to update the consensus script so that the output is created in the current working directory for compatibility with Docker and CWL, and to update the name of the output file to change the basename to the user-provided value. These are equivalent to the same changes recently made to the add_strelka2_fields script, and for the same reasons. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I did not separately test the main functionality of the script, only that the new output file name and location were generated correctly. However, it can be tested by the same means and with the same files as https://github.com/kids-first/kf-somatic-workflow/pull/81

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have committed any related changes to the PR
