### PR TITLE
:bug: assign to alleles, avoid INFO END

### DIFF
--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -617,7 +617,8 @@ if __name__ == "__main__":
 
         for caller_var in varlist:
             try:
-                if caller_var.record.info['HotSpotAllele']:
+                # HotSpotAllele INFO field is stored as length-1 tuple 
+                if caller_var.record.info['HotSpotAllele'][0]:
                     hotspot = True
                     record = build_output_record(varlist, output_vcf, sample_names,
                             hotspot=True)

--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -463,8 +463,7 @@ def build_output_record(single_caller_variants, output_vcf, sample_names, hotspo
     # Set consistent attributes
     liftover_record = single_caller_variants[0].record
     output_record.chrom = liftover_record.chrom
-    output_record.ref = liftover_record.ref
-    output_record.alts = liftover_record.alts
+    output_record.alleles = liftover_record.alleles
     output_record.id = liftover_record.id
     output_record.start = liftover_record.start
     output_record.stop = liftover_record.stop


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Building consensus records in pysam was adding an unused INFO field END to the VCF header. It turns out that this does not occur if you assign to VariantRecord.alleles instead of ref and alts. 

This also gets the value of the HotSpotAllele INFO field correctly. 

Fixes https://github.com/d3b-center/bixu-tracker/issues/958

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested on instance

**Test Configuration**:
* Environment: 
* python 3.8.5
* pysam 0.16.0.1 built against samtools 1.10
* Test files: see https://cavatica.sbgenomics.com/u/nathanj/test-project/tasks/9ce481b6-a3e4-4b2a-8ed4-70fdd0656366/

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
