### PR TITLE
✨ Nhj public output

### DIFF
--- a/workflow/kfdrc_consensus_calling.cwl
+++ b/workflow/kfdrc_consensus_calling.cwl
@@ -19,7 +19,7 @@ inputs:
   output_basename: string
   annotation_vcf: {type: File, secondaryFiles: ['.tbi'], doc: "VCF of annotions to add to consensus variants, e.g. gnomAD allele frequency"}
   vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
-  bcftools_public_filter: {type: string?, doc: "Will hard filter final result to create a public version", default: FILTER="PASS"|INFO/HotSpotAllele=1}
+  bcftools_public_filter: {type: string?, doc: "Will hard filter final result to create a public version", default: FILTER="PASS"|INFO/Hotspot=1}
   retain_info: {type: string?, doc: "csv string with INFO fields that you want to keep, i.e. for consensus `MQ,MQ0,CAL,HotSpotAllele`"}
   retain_fmt: {type: string?, doc: "csv string with FORMAT fields that you want to keep"}
   use_kf_fields: {type: boolean?, doc: "Flag to drop fields normally not used in KF, or keep cBio defaults", default: true}

--- a/workflow/kfdrc_consensus_calling.cwl
+++ b/workflow/kfdrc_consensus_calling.cwl
@@ -28,8 +28,6 @@ inputs:
   use_kf_fields: {type: boolean?, doc: "Flag to drop fields normally not used in KF, or keep cBio defaults", default: true}
 
 outputs:
-#  vep_consensus_vcf: {type: File, outputSource: variant_filter/gatk_soft_filtered_vcf, secondaryFiles: ['.tbi']}
-#  vep_consensus_maf: {type: File, outputSource: vcf2maf/output_maf}
   annotated_protected_outputs: {type: 'File[]', outputSource: rename_protected/renamed_files}
   annotated_public_outputs: {type: 'File[]', outputSource: rename_public/renamed_files}
 

--- a/workflow/kfdrc_consensus_calling.cwl
+++ b/workflow/kfdrc_consensus_calling.cwl
@@ -19,8 +19,8 @@ inputs:
   output_basename: string
   annotation_vcf: {type: File, secondaryFiles: ['.tbi'], doc: "VCF of annotions to add to consensus variants, e.g. gnomAD allele frequency"}
   vep_cache: {type: File, doc: "tar gzipped cache from ensembl/local converted cache"}
-  bcftools_public_filter: {type: string?, doc: "Will hard filter final result to create a public version", default: FILTER="PASS"|INFO/Hotspot=1}
-  retain_info: {type: string?, doc: "csv string with INFO fields that you want to keep, i.e. for consensus `MQ,MQ0,CAL,HotSpotAllele`"}
+  bcftools_public_filter: {type: string?, doc: "Will hard filter final result to create a public version", default: 'FILTER="PASS"|INFO/Hotspot=1'}
+  retain_info: {type: string?, doc: "csv string with INFO fields that you want to keep, i.e. for consensus `MQ,MQ0,CAL,HotSpotAllele`", default: 'MQ,MQ0,CAL,HotSpotAllele'}
   retain_fmt: {type: string?, doc: "csv string with FORMAT fields that you want to keep"}
   use_kf_fields: {type: boolean?, doc: "Flag to drop fields normally not used in KF, or keep cBio defaults", default: true}
 

--- a/workflow/kfdrc_consensus_calling.cwl
+++ b/workflow/kfdrc_consensus_calling.cwl
@@ -91,7 +91,7 @@ steps:
       filter_name: filter_names
       filter_expression:
         source: [input_normal_name, depth_lowerbound, frequency_upperbound]
-        valueFrom: ${return [ "vc.getGenotype(" + self[0] + ").getDP() <= " + self[1], "AF > " + self[2] ]}
+        valueFrom: ${return [ "vc.getGenotype('" + self[0] + "').getDP() <= " + self[1], "AF > " + self[2] ]}
     out: [gatk_soft_filtered_vcf]
 
   vcf2maf:


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This is create public and protected consensus outputs per #1045 and also incorporates some of the flexible-input stuff from #1021, although it does not address filtering expressions. 

Fixes https://github.com/d3b-center/bixu-tracker/issues/1045

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- 
## How Has This Been Tested?

One question relates to the retained info input, which is used by both the vcf2maf and kfdrc_vcf2maf_public steps. Do these in fact use the same retained info, or are two inputs needed, one for each step? 

- [X] On Cavatica: https://cavatica.sbgenomics.com/u/nathanj/test-project/tasks/8624221d-33eb-4245-8def-7c1f8ef934a4/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
