### PR TITLE
🔧 Hotspot -> HotSpotAllele

### DIFF
--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -252,7 +252,7 @@ def write_output_header(output_vcf, sample_list, contig_list, hotspot_source=Non
             sample_list (pysam.libcbcf.VariantHeaderSamples): samples to write into header
             contig_list (list of pysam.libcbcf.VariantContig objects):
                 names of contigs to write into header
-            hotspot_source (str): information about source of 'Hotspot' designated regions
+            hotspot_source (str): information about source of 'HotSpotAllele' designated regions
                 for inclusion in header; default None
     """
     # Version is set to VCF4.2 on creation
@@ -272,7 +272,7 @@ def write_output_header(output_vcf, sample_list, contig_list, hotspot_source=Non
             'Number of MAPQ=0 reads (normal sample)')
     output_vcf.header.info.add('CAL','.','String',
             'List of callers making this call')
-    output_vcf.header.info.add('Hotspot', 0, 'Flag',
+    output_vcf.header.info.add("HotSpotAllele",'A','Integer',
             'Included by exception to consensus rule due to hotspot status%s' % hotspot_string)
     output_vcf.header.formats.add('GT', '1', 'String',
             'Consensus genotype')
@@ -521,8 +521,7 @@ def build_output_record(single_caller_variants, output_vcf, sample_names, hotspo
 
     output_record.info['CAL'] = ','.join([c for c in CALLER_NAMES if c.lower() in variant_lookup])
 
-    if hotspot:
-        output_record.info['Hotspot'] = True
+    output_record.info['HotSpotAllele'] = (int(hotspot),)
 
     output_record.filter.add('PASS')
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Formerly the INFO label for hotspots in the consensus VCF was different from how it appeared in the single-caller VCFs. This is to harmonize those workflow outputs on this point. 

I believe this is a ticketless hotfix. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Ran on instance and saw desired labels in output. 

**Test Configuration**:
* Environment: python 3.8.5, pysam 0.16.0.1, samtools 1.10
* Test files: Can be tested using inputs at 
https://cavatica.sbgenomics.com/u/nathanj/test-project/tasks/d5f469dd-fc9a-4680-bdcd-ca081ea01e04/

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
