### PR TITLE
✨ Nhj consensus contigs

### DIFF
--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -177,7 +177,7 @@ class Variant(object):
             Then based on chromosomal coordinate, as 'int'
             Then alphabetically by first alternate allele
         """
-        def order_chroms(chrom1, chrom2):
+        def order_chroms(chr1, chr2):
             """ Establish correct sort order for canonical human chromosomes
                 Returns True if chrom1 < chrom2, else False
             """

--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -181,11 +181,6 @@ class Variant(object):
             """ Establish correct sort order for canonical human chromosomes
                 Returns True if chrom1 < chrom2, else False
             """
-
-            for name in chr1, chr2:
-                if name not in ALLOWED_CHROMS:
-                    raise ValueError('Uncanonical chromosome %s uncomparable' % name)
-
             return ALLOWED_CHROMS.index(chr1) < ALLOWED_CHROMS.index(chr2)
 
         if not isinstance(other, Variant):
@@ -285,6 +280,7 @@ def write_output_header(output_vcf, sample_list, contig_list, hotspot_source=Non
 
 def get_all_variants(caller_name, pysam_vcf):
     """ Ingest all records from a pysam VCF object
+        Excludes records associated with chromosomes not allowed by user
 
         Args:
             caller_name (str)
@@ -295,7 +291,8 @@ def get_all_variants(caller_name, pysam_vcf):
                 'caller' attribute of Variants will be caller_name.
     """
 
-    all_records = sorted([Variant(rec, caller_name) for rec in pysam_vcf.fetch()])
+    all_records = sorted([Variant(rec, caller_name) for rec in pysam_vcf.fetch() 
+                          if rec.chrom in ALLOWED_CHROMS])
     return {caller_name: all_records}
 
 def find_variant_callers(variant_list, all_variants_dict):

--- a/scripts/consensus_merge.py
+++ b/scripts/consensus_merge.py
@@ -26,9 +26,6 @@ import pysam
 
 # Ordered list of names of callers being used for consensus
 CALLER_NAMES = ('Strelka2', 'Mutect2', 'VarDict', 'Lancet')
-# Only certain contigs will be permitted in the output VCF,
-#     but the list depends on user input 
-ALLOWED_CHROMS = []
 # Character for separating caller information in FORMAT fields
 FORMAT_JOIN = '|'
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This gets rid of the rigid canonical version of ALLOWED_CHROMS and adopts instead the contigs provided by the user in a BED file or, if none is provided, the contigs in the Strelka2 VCF header. Variants not in an allowed contig do not appear in the consensus output. 

Fixes https://github.com/d3b-center/bixu-tracker/issues/1085
New Dockerfile in bixtools and update to CWL tool will be needed to actually implement the change in the workflow. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested with and without provided BED file on EC2 instance with inputs from
https://cavatica.sbgenomics.com/u/nathanj/test-project/tasks/d5f469dd-fc9a-4680-bdcd-ca081ea01e04/
Note VEP cache, AF VCF not needed. 
Testing BED file and outputs for both are in 
https://cavatica.sbgenomics.com/u/nathanj/test-project/files/#q?path=consensus_test_output

**Test Configuration**:
* Environment: Python 3.8.5, pysam 0.16.0.1, samtools 1.10
* Test files: See above

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
