### PR TITLE
🐛 etool type workaround sbg errors

### DIFF
--- a/tools/expression_flatten_list.cwl
+++ b/tools/expression_flatten_list.cwl
@@ -4,9 +4,9 @@ id: expression_flatten_list
 requirements:
   - class: InlineJavascriptRequirement
 inputs:
-  input_list: 'Any[]?'
+  input_list: { type: 'Any[]?' }
 outputs:
-  output: 'Any[]?'
+  output: { type: 'Any[]?' }
 expression: |
   ${
     var flatten = function flatten(ary) {

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -748,5 +748,5 @@ sbg:categories:
 - VCF
 - VEP
 sbg:links:
-- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v2.3.3'
+- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v2.3.4'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

SBG has an issue where expression tool types need to be explicitly defined or their editor will throw errors. Our latest somatic workflow release has these errors so I fixed them.

Can't really test because the main workflow is under 🚧 by @migbro but the expressiontool errors are now gone.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Can't really do it

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
