### PR TITLE
🤔 Added optional strelka2 params

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can use the `include_expression` `Filter="PASS"` to achieve this.
     - `af_only_gnomad_vcf`: [af-only-gnomad.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/-gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
     - `exac_common_vcf`: [small_exac_common_3.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
     - `hg38_strelka_bed`: [hg38_strelka.bed.gz'](https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md#extended-use-cases) - this link here has the bed-formatted text needed to copy to create this file. You will need to bgzip this file.
-    - `extra_arg`: This can be used to add special params to strelka2. It is currently more of an "unsticking param". For edge cases where strelka2 seems to hang, setting this to `--max-input-depth 1000` can balance performance and consistency in results
+    - `extra_arg`: This can be used to add special params to strelka2. It is currently more of an "unsticking param". For edge cases where strelka2 seems to hang, setting this to `--max-input-depth 10000` can balance performance and consistency in results
     - strelka2_cores: `18`. This default is already set, but can be changed if desired.
     - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
      Current production workflow uses this version.

--- a/README.md
+++ b/README.md
@@ -117,10 +117,12 @@ You can use the `include_expression` `Filter="PASS"` to achieve this.
     - `af_only_gnomad_vcf`: [af-only-gnomad.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/-gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
     - `exac_common_vcf`: [small_exac_common_3.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
     - `hg38_strelka_bed`: [hg38_strelka.bed.gz'](https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md#extended-use-cases) - this link here has the bed-formatted text needed to copy to create this file. You will need to bgzip this file.
-     - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
+    - `extra_arg`: This can be used to add special params to strelka2. It is currently more of an "unsticking param". For edge cases where strelka2 seems to hang, setting this to `--max-input-depth 1000` can balance performance and consistency in results
+    - strelka2_cores: `18`. This default is already set, but can be changed if desired.
+    - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
      Current production workflow uses this version.
-     - `threads`: 16
-     - `chr_len`: hs38_chr.len, this a tsv file with chromosomes and their lengths. Should be limited to canonical chromosomes
+    - `threads`: 16
+    - `chr_len`: hs38_chr.len, this a tsv file with chromosomes and their lengths. Should be limited to canonical chromosomes
       The first column must be chromosomes, optionally the second can be an alternate format of chromosomes.
       Last column must be chromosome length.
       Using the `hg38_strelka_bed`, and removing chrM can be a good source for this.

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -60,6 +60,7 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: string?, doc: "Sequencing center of variant called", default: "."}
+  strelka2_cores: {type: int?, doc: "Adjust number of cores used to run strelka2", default: 16}
   extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
 
 outputs:
@@ -80,6 +81,7 @@ steps:
       use_manta_small_indels: use_manta_small_indels
       exome_flag: exome_flag
       extra_arg: extra_arg
+      cores: strelka2_cores
     out: [output_snv, output_indel]
 
   merge_strelka2_vcf:

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -60,6 +60,7 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: string?, doc: "Sequencing center of variant called", default: "."}
+  extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
 
 outputs:
   strelka2_prepass_vcf: {type: File, outputSource: rename_strelka_samples/reheadered_vcf}
@@ -78,6 +79,7 @@ steps:
       manta_small_indels: manta_small_indels
       use_manta_small_indels: use_manta_small_indels
       exome_flag: exome_flag
+      extra_arg: extra_arg
     out: [output_snv, output_indel]
 
   merge_strelka2_vcf:

--- a/tools/strelka2.cwl
+++ b/tools/strelka2.cwl
@@ -82,7 +82,7 @@ inputs:
         }
       }
     doc: "normal BAM or CRAM"
-  cores: {type: ['null', int], default: 18}
+  cores: {type: ['null', int], default: 16}
   extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
 outputs:
   output_snv:

--- a/tools/strelka2.cwl
+++ b/tools/strelka2.cwl
@@ -17,7 +17,7 @@ arguments:
     valueFrom: >-
       ${
         if (inputs.extra_arg){
-          var cmd = "sed  -e 's/extraVariantCallerArguments.*/"
+          var cmd = "sed  -e 's/extraVariantCallerArguments.*/extraVariantCallerArguments = "
           + inputs.extra_arg + "/' /strelka-2.9.3.centos6_x86_64/bin/configureStrelkaSomaticWorkflow.py.ini > config.ini && "
           return cmd
         }

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -277,6 +277,7 @@ inputs:
       class: File, path: 5f500135e4b0370371c051ae, name: hg38_strelka.bed.gz}}
   hg38_strelka_tbi: {type: 'File?', doc: "Tabix index for hg38_strelka_bed", sbg:suggestedValue: {
       class: File, path: 5f500135e4b0370371c051aa, name: hg38_strelka.bed.gz.tbi}}
+  extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
   mutect2_af_only_gnomad_vcf: {type: File, sbg:suggestedValue: {class: File, path: 5f50018fe4b054958bc8d2e3,
       name: af-only-gnomad.hg38.vcf.gz}}
   mutect2_af_only_gnomad_tbi: {type: 'File?', doc: "Tabix index for mutect2_af_only_gnomad_vcf",
@@ -657,6 +658,7 @@ steps:
       manta_small_indels: run_manta/manta_small_indels
       use_manta_small_indels: use_manta_small_indels
       exome_flag: choose_defaults/out_exome_flag
+      extra_arg: extra_arg
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -278,6 +278,7 @@ inputs:
   hg38_strelka_tbi: {type: 'File?', doc: "Tabix index for hg38_strelka_bed", sbg:suggestedValue: {
       class: File, path: 5f500135e4b0370371c051aa, name: hg38_strelka.bed.gz.tbi}}
   extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
+  strelka2_cores: {type: int?, doc: "Adjust number of cores used to run strelka2", default: 18}
   mutect2_af_only_gnomad_vcf: {type: File, sbg:suggestedValue: {class: File, path: 5f50018fe4b054958bc8d2e3,
       name: af-only-gnomad.hg38.vcf.gz}}
   mutect2_af_only_gnomad_tbi: {type: 'File?', doc: "Tabix index for mutect2_af_only_gnomad_vcf",
@@ -659,6 +660,7 @@ steps:
       use_manta_small_indels: use_manta_small_indels
       exome_flag: choose_defaults/out_exome_flag
       extra_arg: extra_arg
+      strelka2_cores: strelka2_cores
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -122,10 +122,12 @@ doc: |
       - `af_only_gnomad_vcf`: [af-only-gnomad.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/-gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
       - `exac_common_vcf`: [small_exac_common_3.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
       - `hg38_strelka_bed`: [hg38_strelka.bed.gz'](https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md#extended-use-cases) - this link here has the bed-formatted text needed to copy to create this file. You will need to bgzip this file.
-       - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
+      - `extra_arg`: This can be used to add special params to strelka2. It is currently more of an "unsticking param". For edge cases where strelka2 seems to hang, setting this to `--max-input-depth 1000` can balance performance and consistency in results
+      - strelka2_cores: `18`. This default is already set, but can be changed if desired.
+      - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
        Current production workflow uses this version.
-       - `threads`: 16
-       - `chr_len`: hs38_chr.len, this a tsv file with chromosomes and their lengths. Should be limited to canonical chromosomes
+      - `threads`: 16
+      - `chr_len`: hs38_chr.len, this a tsv file with chromosomes and their lengths. Should be limited to canonical chromosomes
         The first column must be chromosomes, optionally the second can be an alternate format of chromosomes.
         Last column must be chromosome length.
         Using the `hg38_strelka_bed`, and removing chrM can be a good source for this.
@@ -277,8 +279,10 @@ inputs:
       class: File, path: 5f500135e4b0370371c051ae, name: hg38_strelka.bed.gz}}
   hg38_strelka_tbi: {type: 'File?', doc: "Tabix index for hg38_strelka_bed", sbg:suggestedValue: {
       class: File, path: 5f500135e4b0370371c051aa, name: hg38_strelka.bed.gz.tbi}}
-  extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
-  strelka2_cores: {type: int?, doc: "Adjust number of cores used to run strelka2", default: 18}
+  extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth\
+      \ 1000"}
+  strelka2_cores: {type: int?, doc: "Adjust number of cores used to run strelka2",
+    default: 18}
   mutect2_af_only_gnomad_vcf: {type: File, sbg:suggestedValue: {class: File, path: 5f50018fe4b054958bc8d2e3,
       name: af-only-gnomad.hg38.vcf.gz}}
   mutect2_af_only_gnomad_tbi: {type: 'File?', doc: "Tabix index for mutect2_af_only_gnomad_vcf",
@@ -846,5 +850,5 @@ sbg:categories:
 - VCF
 - VEP
 sbg:links:
-- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v3.0.0'
+- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v3.0.1'
   label: github-release

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -122,7 +122,7 @@ doc: |
       - `af_only_gnomad_vcf`: [af-only-gnomad.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/-gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
       - `exac_common_vcf`: [small_exac_common_3.hg38.vcf.gz](https://console.cloud.google.com/storage/browser/gatk-best-practices/somatic-hg38) - need a valid google account, this is a link to the best practices google bucket from Broad GATK.
       - `hg38_strelka_bed`: [hg38_strelka.bed.gz'](https://github.com/Illumina/strelka/blob/v2.9.x/docs/userGuide/README.md#extended-use-cases) - this link here has the bed-formatted text needed to copy to create this file. You will need to bgzip this file.
-      - `extra_arg`: This can be used to add special params to strelka2. It is currently more of an "unsticking param". For edge cases where strelka2 seems to hang, setting this to `--max-input-depth 1000` can balance performance and consistency in results
+      - `extra_arg`: This can be used to add special params to strelka2. It is currently more of an "unsticking param". For edge cases where strelka2 seems to hang, setting this to `--max-input-depth 10000` can balance performance and consistency in results
       - strelka2_cores: `18`. This default is already set, but can be changed if desired.
       - `vep_cache`: `homo_sapiens_vep_93_GRCh38.tar.gz` from ftp://ftp.ensembl.org/pub/release-93/variation/indexed_vep_cache/ - variant effect predictor cache.
        Current production workflow uses this version.
@@ -280,7 +280,7 @@ inputs:
   hg38_strelka_tbi: {type: 'File?', doc: "Tabix index for hg38_strelka_bed", sbg:suggestedValue: {
       class: File, path: 5f500135e4b0370371c051aa, name: hg38_strelka.bed.gz.tbi}}
   extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth\
-      \ 1000"}
+      \ 10000"}
   strelka2_cores: {type: int?, doc: "Adjust number of cores used to run strelka2",
     default: 18}
   mutect2_af_only_gnomad_vcf: {type: File, sbg:suggestedValue: {class: File, path: 5f50018fe4b054958bc8d2e3,

--- a/workflow/kfdrc_production_strelka2_wf.cwl
+++ b/workflow/kfdrc_production_strelka2_wf.cwl
@@ -47,6 +47,7 @@ inputs:
       class: File, path: 5f500135e4b0370371c051aa, name: hg38_strelka.bed.gz.tbi} }
   output_basename: { type: string, doc: "String value to use as basename for outputs" }
   wgs_or_wxs: { type: { type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS" }
+  extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
 
   # Optional with One Default
   select_vars_mode: { type: ['null', { type: enum, name: select_vars_mode, symbols: ["gatk", "grep"] }], default: "gatk", doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression" }
@@ -121,6 +122,7 @@ steps:
       manta_small_indels: manta_small_indels
       use_manta_small_indels: use_manta_small_indels
       exome_flag: exome_flag
+      extra_arg: extra_arg
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build
       output_basename: output_basename

--- a/workflow/kfdrc_production_strelka2_wf.cwl
+++ b/workflow/kfdrc_production_strelka2_wf.cwl
@@ -48,6 +48,7 @@ inputs:
   output_basename: { type: string, doc: "String value to use as basename for outputs" }
   wgs_or_wxs: { type: { type: enum, name: sex, symbols: ["WGS", "WXS"] }, doc: "Select if this run is WGS or WXS" }
   extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
+  strelka2_cores: {type: int?, doc: "Adjust number of cores used to run strelka2", default: 16}
 
   # Optional with One Default
   select_vars_mode: { type: ['null', { type: enum, name: select_vars_mode, symbols: ["gatk", "grep"] }], default: "gatk", doc: "Choose 'gatk' for SelectVariants tool, or 'grep' for grep expression" }
@@ -122,6 +123,7 @@ steps:
       manta_small_indels: manta_small_indels
       use_manta_small_indels: use_manta_small_indels
       exome_flag: exome_flag
+      strelka2_cores: strelka2_cores
       extra_arg: extra_arg
       vep_cache: vep_cache
       vep_ref_build: vep_ref_build


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR addresses an edge case in which strelka2 hangs in very high depth regions. Solution employs parameter outlined here: https://github.com/Illumina/strelka/issues/168
With value in practice to be set to `--max-input-depth 10000` as recommend by @kgaonkar6 and @komalsrathi 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] [Existing sample re-run](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/bae2cda0-8c9f-4a8f-8a2c-eb88aa2e889a/)
- [ ] Compare to [original vcf](https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-bhjxbdqk-ad-hoc-caller-rerun/tasks/59defd04-f556-4515-a9f6-b431a1da33f4/ using `bcftools isec`
- [ ] [Affected sample run](https://cavatica.sbgenomics.com/u/zhangb1/kf-somatic-tools-test/tasks/27bae288-a3a3-4ede-9dab-d3f7f481e97d/)

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
