### PR TITLE
🐛  gatk cnv interval gets its own input

### DIFF
--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -61,7 +61,7 @@ doc: |
   #### SNV Callers
 
   - [Strelka2](https://github.com/Illumina/strelka/tree/v2.9.3) `v2.9.3`, from Illumina, calls single nucleotide variants (SNV) and insertions/deletions (INDEL)
-    - See the [subworkflow doc](https://github.com/kids-first/kf-somatic-workflow/blob/master/docs/kfdrc_strelka2_subworkflow.md) for more information 
+    - See the [subworkflow doc](https://github.com/kids-first/kf-somatic-workflow/blob/master/docs/kfdrc_strelka2_subworkflow.md) for more information
   - [Mutect2](https://gatk.broadinstitute.org/hc/en-us/articles/360036730411-Mutect2) `v4.1.1.0`, from the Broad institute, calls SNV, multi-nucleotide variants (MNV, basically equal length substitutions with length > 1) and INDEL
     - This workflow will generate the interval lists needed to split up calling jobs to significantly reduce run time
     - Those intervals are used to run the [Mutect2 subworkflow](https://github.com/kids-first/kf-somatic-workflow/blob/master/docs/kfdrc_mutect2_sub_wf.md)
@@ -296,8 +296,12 @@ inputs:
       \ if this run is WGS or WXS"}
 
   # GATK CNV Inputs
-  input_exclude_interval_list: {type: 'File?', secondaryFiles: [{pattern: ".tbi",
-        required: false}], doc: "Picard or GATK-style interval list file of regions\
+  gatk_cnv_input_interval_list: {type: 'File?', secondaryFiles: [{pattern: ".tbi", required: false}],
+    doc: "For GATK CNV Calling: Picard or GATK-style interval list file of regions to analyze. For WGS,\
+      \ this should typically only include the autosomal chromosomes.", 'sbg:fileTypes': "INTERVALS,\
+      \ INTERVAL_LIST, LIST, BED, VCF, VCF.GZ"}
+  gatk_cnv_input_exclude_interval_list: {type: 'File?', secondaryFiles: [{pattern: ".tbi",
+        required: false}], doc: "For GATK CNV Calling: Picard or GATK-style interval list file of regions\
       \ to ignore.", "sbg:fileTypes": "INTERVALS, INTERVAL_LIST, LIST, BED, VCF, VCF.GZ"}
   count_panel_of_normals: {type: 'File?', doc: "Path to read-count PoN created by\
       \ the panel workflow. Significantly reduces quality of calling if not provided!",
@@ -425,7 +429,7 @@ inputs:
   # WXS only Fields
   padded_capture_regions: {type: 'File?', doc: "Recommend 100bp pad, for somatic variant"}
   unpadded_capture_regions: {type: 'File?', doc: "Capture regions with NO padding\
-      \ for cnv calling"}
+      \ for ControlFreeC exome mode CNV calling."}
 
 outputs:
   ctrlfreec_pval: {type: 'File', outputSource: run_controlfreec/ctrlfreec_pval}
@@ -870,8 +874,8 @@ steps:
       input_aligned_reads_normal: input_normal_aligned
       reference_fasta: prepare_reference/indexed_fasta
       reference_dict: prepare_reference/reference_dict
-      input_interval_list: unpadded_capture_regions
-      input_exclude_interval_list: input_exclude_interval_list
+      input_interval_list: gatk_cnv_input_interval_list
+      input_exclude_interval_list: gatk_cnv_input_exclude_interval_list
       bin_length:
         source: wgs_or_wxs
         valueFrom: |


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Issue discovered by @zhangb1 where setting the unpadded_capture_intervals for GATK CNV in a WGS sample would cause ControlFreeC to error. 

To circumvent the error, GATK CNV is getting its own input_interval_list workflow input. Also made the input more explicit because we have so many interval_list and capture_region inputs for this workflow that it makes my head hurt.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/d3b-bixu-ops/sd-q8d06qqh-somatic-mutations-wgs-tumor/tasks/49c46d2e-7fe0-43ee-b80e-2384b9314034/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
