### PR TITLE
🔧 added flag to fix bug when vcf is empty

### DIFF
--- a/tools/variant_effect_predictor_105.cwl
+++ b/tools/variant_effect_predictor_105.cwl
@@ -118,6 +118,7 @@ arguments:
           return " --no_stats ";
         }
       }
+      --format vcf
       --warning_file $(inputs.output_basename)_warnings.$(inputs.tool_name).txt
       --buffer_size $(inputs.buffer_size)
       --vcf

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -1099,5 +1099,5 @@ hints:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v4.3.1'
+- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v4.3.2'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

New VEP tool would fail with empty call input.
I have added in an old flag from the old tool.
Basically it hard codes input as VCF instead of auto-detect.
Until we decide/want to use the tool for other input formats, this is fine.
Otherwise, in the future, we can make it an enum


Fixes # https://github.com/d3b-center/bixu-tracker/issues/1717

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] https://cavatica.sbgenomics.com/u/d3b-bixu/dev-wgsa/tasks/f7c0250c-1c73-4f7d-9021-050f45046562/
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
