### PR TITLE
🐛  hotspot splice protein pos fix

### DIFF
--- a/scripts/hotspot.py
+++ b/scripts/hotspot.py
@@ -6,6 +6,7 @@ import os
 import pysam
 import gzip
 import re
+import math
 
 def parse_command():
     """Function to parse the command line input
@@ -175,8 +176,8 @@ def create_splice_hgvsp_short(csq_record,csq_items,cons_field="Consequence",cdna
         cdna_pos = csq_record.split('|')[csq_items.index(cdna_field)]
         m = re.search(r"c\.(-?\d+)",cdna_pos) # Search for coding DNA reference sequence
         if m: # If we match
-            cdna_val = 1 if int(m[1]) < 0 else int(m[1]) # Rescue the negative value cDNA positions used in 5' UTRs
-            pro_val = int((cdna_val + cdna_val % 3) / 3) # Recalculate protein position and drop the decimals
+            cdna_val = max(1, int(m[1])) # Set zero/negative cDNA values (positions in the 5' UTR) to 1
+            pro_val = math.ceil(cdna_val / 3) # Convert cDNA to protein position
             short = "X{}_splice".format(pro_val)
         elif cdna_pos:
             print("Warning! Could not process HGVSc: {} of CSQ:{}{}{}".format(cdna_pos,chr(10),chr(9),csq_record))

--- a/scripts/hotspot.py
+++ b/scripts/hotspot.py
@@ -268,7 +268,7 @@ def process_vcf(infile,outfile,genomic_hs,hugo_hs,fid,pos='HGVSp',allele='ALLELE
                     continue # Protein positions could not be interpreted. Continue to next CSQ
                 protein_range = (protein_start, protein_end + 1) # Convert inclusive to non-inclusive end
                 var_class = i.split('|')[csq_items.index(variant_class)]
-                var_class = 'INDEL' if var_class in ['SNV', 'substitution'] else 'SNV'
+                var_class = 'INDEL' if var_class not in ['SNV', 'substitution'] else 'SNV'
                 if field_id in hugo_hs and protein_range in hugo_hs[field_id][var_class]: # Flag all exact matches
                     flagged.append("Hugo_Symbol:{} AA_Start:{} AA_End:{}".format(field_id,protein_range[0],protein_range[1]-1)) # uncorrect the inclusive addition
                     hotspot_alleles.append(i.split('|')[csq_items.index(allele)])

--- a/tools/hotspots_annotation.cwl
+++ b/tools/hotspots_annotation.cwl
@@ -21,12 +21,34 @@ arguments:
     valueFrom: >-
       $(inputs.disable_hotspot_annotation ? ">&2 echo 'User elected to skip hotspot annotation' && exit 0;" : ">&2 python hotspot.py")
 inputs:
+  # Main Arguments
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task." }
   input_vcf: { type: 'File', inputBinding: { position: 99, prefix: '--vcf', shellQuote: false }, secondaryFiles: [.tbi], doc: "VCF file to annotate hotspots." }
-  genomic_hotspots: { type: 'File[]?', inputBinding: { position: 1, prefix: '--genomic_hotspots', shellQuote: false }, doc: "Tab-delimited BED formatted file(s) containing hg38 genomic positions corresponding to hotspots" }
-  protein_indels: { type: 'File[]?', inputBinding: { position: 1, prefix: '--protein_indels', shellQuote: false }, doc: "Column name-labeled, tab-delimited file(s) containing HUGO-formatted protein names and VEP-formatted positions <start_aa_pos>-<end_aa_pos> for INDEL hotspots" }
-  protein_snvs: { type: 'File[]?', inputBinding: { position: 1, prefix: '--protein_snvs', shellQuote: false }, doc: "Column name-labeled, tab-delimited file(s) containing HUGO-formatted protein names and VEP-formatted positions <start_aa_pos> for SNV hotspots" }
+  genomic_hotspots: { type: 'File[]?', inputBinding: { position: 1, prefix: '--genomic_hotspots', shellQuote: false }, doc: "Tab-delimited BED-formatted (chrom, zero-based chromStart, non-inclusive chromEnd) file(s) containing hg38 genomic positions corresponding to hotspots" }
+  protein_indels: { type: 'File[]?', inputBinding: { position: 1, prefix: '--protein_indels', shellQuote: false }, doc: "Column name-labeled, tab-delimited file(s) containing HUGO-formatted protein names and VEP-formatted positions <start_aa_pos> for SNV hotspots" }
+  protein_snvs: { type: 'File[]?', inputBinding: { position: 1, prefix: '--protein_snvs', shellQuote: false }, doc: "Column name-labeled, tab-delimited file(s) containing HUGO-formatted protein names and VEP-formatted positions <start_aa_pos>-<end_aa_pos> for INDEL hotspots" }
   output_basename: { type: 'string?', inputBinding: { position: 10, prefix: '--output_basename', shellQuote: false }, doc: "String to use as basename for output file" }
+
+  # Advanced Arguments
+  protein_colname: { type: 'string?', inputBinding: { position: 2, prefix: "--protein_colname" }, doc: "Overrides the column name in the protein_hotspots file(s) that contains the protein name information" }
+  position_colname: { type: 'string?', inputBinding: { position: 2, prefix: "--position_colname" }, doc: "Overrides the column name in the protein_hotspots file(s) that contains the HGVSp short information" }
+  csq_field: { type: 'string?', inputBinding: { position: 2, prefix: "--csq_field" }, doc: "Overrides the name of the CSQ field that matches the values found in the protein_colname of the protein_hotspots input(s)" }
+  csq_pos:
+    type:
+      - 'null'
+      - type: enum
+        name: csq_pos
+        symbols: ["HGVSp","Protein_position"]
+    inputBinding:
+      position: 2
+      prefix: "--csq_pos"
+    doc: |
+      Overrides the name of the CSQ field that stores protein position information. Currently capable of processing Protein_position or HGVSp.
+  csq_allele: { type: 'string?', inputBinding: { position: 2, prefix: "--csq_allele" }, doc: "Overrides the name of the CSQ field that stores allele number information" }
+  csq_impact: { type: 'string?', inputBinding: { position: 2, prefix: "--csq_impact" }, doc: "Overrides the name of the CSQ field that stores impact information" }
+  csq_class: { type: 'string?', inputBinding: { position: 2, prefix: "--csq_class" }, doc: "Overrides the name of the CSQ field that stores variant class information" }
+
+  # Resource Control
   ram: { type: 'int?', default: 2, doc: "GB of RAM to allocate to this task." }
   cores: { type: 'int?', default: 1, doc: "CPU cores to allocate to this task." }
 outputs:

--- a/tools/hotspots_annotation.cwl
+++ b/tools/hotspots_annotation.cwl
@@ -1,23 +1,25 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 id: hotspots_annotation
 requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
-    ramMin: ${ return inputs.ram * 1000 }
+    ramMin: $(inputs.ram * 1000)
     coresMin: $(inputs.cores)
   - class: DockerRequirement
-    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/hotspots:0.1.0'
-
+    dockerPull: 'quay.io/biocontainers/pysam:0.21.0--py310h41dec4a_1'
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: hotspot.py
+        entry:
+          $include: ../scripts/hotspot.py
 baseCommand: []
-
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      $(inputs.disable_hotspot_annotation ? ">&2 echo 'User elected to skip hotspot annotation' && exit 0;" : ">&2 /hotspot.py")
-
+      $(inputs.disable_hotspot_annotation ? ">&2 echo 'User elected to skip hotspot annotation' && exit 0;" : ">&2 python hotspot.py")
 inputs:
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task." }
   input_vcf: { type: 'File', inputBinding: { position: 99, prefix: '--vcf', shellQuote: false }, secondaryFiles: [.tbi], doc: "VCF file to annotate hotspots." }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Primary Changes:
- Fixes an issue where protein position for splice hotspots was being incorrectly calculated.
- `VARIANT_CLASS: substitution` will now check against the SNV hotspots
- Now using HGVSp to determine start and end positions, by default
- Rather than requiring multi AA variants to both start and end within the hotspot we now allow them to be off by 1. They can either start 1 AA prior to the hotspot start or end 1 AA after the hotspot end (but not both!). We're adding this feature on account of the complexity of HGVSp and our uncertainty with how it exactly correlates with the MSKCC hotspot positions.

Other Changes:
- Stylistic changes to hotspot annotation CWL.
- Changed to public docker with script importing.
- Removed deprecated varaible

Closes https://github.com/d3b-center/bixu-tracker/issues/1921

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] https://cavatica.sbgenomics.com/u/zhangb1/opentagret-4-callers-vcf-temp-holder/tasks/9c11c11d-b922-4d8f-8e94-a6fbe2c3b2e3/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
