### PR TITLE
🚀 Annot WF Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ You can use the `include_expression` `Filter="PASS"` to achieve this.
     - `bcftools_public_filter`: `'FILTER="PASS"|INFO/HotSpotAllele=1'`. This phrase will allow `PASS` only **or** `HotSpotAllele` variants into the public version of variant call output.
     - `gatk_filter_name`: `["NORM_DP_LOW", "GNOMAD_AF_HIGH"]`. These correspond to the recommended filter expression
     - `gatk_filter_expression`: `["vc.getGenotype('<input_normal_name> ').getDP() <= 7"), "gnomad_3_1_1_AF > 0.001"]`. Array of filter expressions to establish criteria to tag variants with. See [annotation subworkflow docs](https://github.com/kids-first/kf-somatic-workflow/blob/master/docs/kfdrc_annotation_subworkflow.md) for a more detailed explanation. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for general JEXL syntax
+    - `custom_enst`: `kf_isoform_override.tsv`. As of VEP 104, several genes have had their canonical transcripts redefined. While the VCF will have all possible isoforms, this affects maf file output and may results in representative protein changes that defy historical expectations
     - `disable_hotspot_annotation`: false
     - `maf_center`: `"."`. Sequencing center of variant called
     - `funcotator_data_sources_tgz`: [funcotator_dataSources.v1.6.20190124s.tar.gz](https://console.cloud.google.com/storage/browser/broad-public-datasets/funcotator) - need a valid google account, this is a link to pre-packaged datasources from the Broad Institute. Any of the tar.gz files will do.

--- a/docs/kfdrc_annotation_wf.md
+++ b/docs/kfdrc_annotation_wf.md
@@ -8,8 +8,8 @@ It does the following things as described below:
 
 1. Normalize VCF
 1. Strip specified `INFO` and `FORMAT` fields (Only if adding a new annotation that clashes with existing)
-1. Annotate with VEP
-1. Annotated with an additional vcf - optional, recommend using a gnomAD VCF with at least AF)
+1. Annotate with VEP - can be skipped if VEP run previously and downstream tools are to be repeated
+1. Annotated with an additional vcf - optional, recommend using a gnomAD VCF with at least AF
 1. Soft filter on remarkable variant characteristics
    - KF recommends normal read depth <= 7 and gnomAD AF > 0.001
    - This output will be considered `protected`
@@ -47,11 +47,12 @@ Secondary files needed for each reference file will be a sub-bullet point
  - `genomic_hotspots`: `tert.bed` # This file has two common TERT promoter gene hot spots
  - `protein_snv_hotspots`: `protein_snv_cancer_hotspots_v2.ENS105_liftover.tsv` # A tsv formatted SNV + MNV subset of https://www.cancerhotspots.org/files/hotspots_v2.xls
  - `protein_indel_hotspots`: `protein_indel_cancer_hotspots_v2.ENS105_liftover.tsv` # A tsv formatted INDEL subset of https://www.cancerhotspots.org/files/hotspots_v2.xls
+ - `custom_enst`: `kf_isoform_override.tsv` # As of VEP 104, several genes have had their canonical transcripts redefined. While the VCF will have all possible isoforms, this affects maf file output and may results in representative protein changes that defy historical expectations
 
 ### Source-specific inputs
 For each input, the sub-bullet refers to when to use the suggested input
  - `add_common_fields`
-   - Strelka2 calls: `true`
+   - Strelka2 calls: `true`, *exception if already run previously and other downstream tools are being run*
    - All others: `false`
  - `retain_info` # This is fairly subjective, some useful columns unique from each caller to carry over from VCF to MAF
    - Strelka2: "gnomad_3_1_1_AC,gnomad_3_1_1_AN,gnomad_3_1_1_AF,gnomad_3_1_1_nhomalt,gnomad_3_1_1_AC_popmax,gnomad_3_1_1_AN_popmax,gnomad_3_1_1_AF_popmax,gnomad_3_1_1_nhomalt_popmax,gnomad_3_1_1_AC_controls_and_biobanks,gnomad_3_1_1_AN_controls_and_biobanks,gnomad_3_1_1_AF_controls_and_biobanks,gnomad_3_1_1_AF_non_cancer,gnomad_3_1_1_primate_ai_score,gnomad_3_1_1_splice_ai_consequence,MQ,MQ0,QSI,HotSpotAllele"
@@ -63,10 +64,11 @@ For each input, the sub-bullet refers to when to use the suggested input
    - Mutect2: "HGVSg"
    - Lancet: "HGVSg"
    - Vardict: "HGVSg"
- - `bcftools_strip_columns` # if reannotating an old file, especially a KF one that had VEP 93 annotation, recommend the following:
-   - "FILTER/GNOMAD_AF_HIGH,FILTER/NORM_DP_LOW,INFO/CSQ,INFO/HotSpotAllele"
+ - `bcftools_strip_columns` # if reannotating an old file:
+   - "FILTER/GNOMAD_AF_HIGH,FILTER/NORM_DP_LOW,INFO/CSQ,INFO/HotSpotAllele" # recommended if re-annotating from an older VEP cache
+   - "FILTER/GNOMAD_AF_HIGH,FILTER/NORM_DP_LOW,INFO/HotSpotAllele" # recommended if repeating hot spot an d want to keep VEP
  - `bcftools_prefilter_csv` # if annotating a file with calls you want screen for, use this. i.e `FILTER="PASS"`
-
+ - `disable_vep_annotation` # set to `True` if existing VEP annotation of file is ok
  - `tool_name`:
    - `Strelka2`: `strelka2_somatic`
    - `Mutect2`: `mutect2_somatic`

--- a/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
+++ b/sub_workflows/kfdrc_controlfreec_sub_wf.cwl
@@ -17,7 +17,7 @@ inputs:
   mate_copynumber_file_control: {type: 'File?', doc: "Normal cpn file from previous run. If used, will override bam use"}
   mate_copynumber_file_sample: {type: 'File?', doc: "Tumor cpn file from previous run. If used, will override bam use"}
   gem_mappability_file: {type: 'File?', doc: "GEM mappability file to make read count adjustments with"}
-  min_subclone_presence: {type: 'float?', doc: "Use if you want to detect sublones. Recommend 0.2 for WGS, 0.3 for WXS"}
+  min_subclone_presence: {type: 'int?', doc: "Use if you want to detect sublones. Recommend 20 for WGS, 30 for WXS"}
   mate_orientation_sample: {type: ['null', {type: enum, name: mate_orientation_sample, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
   mate_orientation_control: {type: ['null', {type: enum, name: mate_orientation_control, symbols: ["0", "FR", "RF", "FF"]}], default: "FR", doc: "0 (for single ends), RF (Illumina mate-pairs), FR (Illumina paired-ends), FF (SOLiD mate-pairs)"}
   capture_regions: {type: ['null', File], doc: "If not WGS, provide "}

--- a/sub_workflows/kfdrc_lancet_sub_wf.cwl
+++ b/sub_workflows/kfdrc_lancet_sub_wf.cwl
@@ -53,6 +53,7 @@ inputs:
   gatk_filter_name: {type: 'string[]', doc: "Array of names for each filter tag to add, recommend: [\"NORM_DP_LOW\", \"GNOMAD_AF_HIGH\"]"}
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK" }
 
 outputs:
   lancet_prepass_vcf: {type: 'File', outputSource: pickvalue_workaround/output}
@@ -148,6 +149,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
       output_basename: output_basename
       tool_name: tool_name
     out: [annotated_protected, annotated_public]

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -57,6 +57,7 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK" }
 
 outputs:
   mutect2_filtered_stats: {type: 'File', outputSource: filter_mutect2_vcf/stats_table}
@@ -193,6 +194,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
       output_basename: output_basename
       tool_name: tool_name
     out: [annotated_protected, annotated_public]

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -71,6 +71,7 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK" }
 
   strelka2_cores: {type: 'int?', doc: "Adjust number of cores used to run strelka2", default: 16}
   extra_arg: {type: 'string?', doc: "Add special options to config file, i.e. --max-input-depth 1000"}
@@ -158,6 +159,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
       output_basename: output_basename
       tool_name: tool_name
     out: [annotated_protected, annotated_public]

--- a/sub_workflows/kfdrc_vardict_sub_wf.cwl
+++ b/sub_workflows/kfdrc_vardict_sub_wf.cwl
@@ -53,6 +53,7 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK" }
   
 outputs:
   vardict_prepass_vcf: {type: 'File', outputSource: pickvalue_workaround/output} 
@@ -163,6 +164,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
       output_basename: output_basename
       tool_name: tool_name
     out: [annotated_protected, annotated_public]

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -500,6 +500,8 @@ inputs:
   disable_hotspot_annotation: {type: 'boolean?', doc: "Disable Hotspot Annotation\
       \ and skip this task.", default: false}
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}] }
 
   # WGS only Fields
   wgs_calling_interval_list: {type: 'File?', doc: "GATK intervals list-style, or bed\
@@ -757,6 +759,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out: [vardict_prepass_vcf, vardict_protected_outputs, vardict_public_outputs]
 
   select_mutect_bed_interval:
@@ -811,6 +814,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out: [mutect2_filtered_stats, mutect2_filtered_vcf, mutect2_protected_outputs,
       mutect2_public_outputs]
 
@@ -855,6 +859,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out: [strelka2_prepass_vcf, strelka2_protected_outputs, strelka2_public_outputs]
 
   bedops_gen_lancet_intervals:
@@ -932,6 +937,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out: [lancet_prepass_vcf, lancet_protected_outputs, lancet_public_outputs]
 
   run_controlfreec:

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -153,6 +153,7 @@ doc: |-
       - `gatk_filter_name`: `["NORM_DP_LOW", "GNOMAD_AF_HIGH"]`. These correspond to the recommended filter expression
       - `gatk_filter_expression`: `["vc.getGenotype('<input_normal_name> ').getDP() <= 7"), "AF > 0.001"]`. Array of filter expressions to establish criteria to tag variants with. See [annotation subworkflow docs](https://github.com/kids-first/kf-somatic-workflow/blob/master/docs/kfdrc_annotation_subworkflow.md) for a more detailed explanation. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration for general JEXL syntax
       - `disable_hotspot_annotation`: false
+      - `custom_enst`: `kf_isoform_override.tsv`. As of VEP 104, several genes have had their canonical transcripts redefined. While the VCF will have all possible isoforms, this affects maf file output and may results in representative protein changes that defy historical expectations
       - `maf_center`: `"."`. Sequencing center of variant called
       - `funcotator_data_sources_tgz`: [funcotator_dataSources.v1.6.20190124s.tar.gz](https://console.cloud.google.com/storage/browser/broad-public-datasets/funcotator) - need a valid google account, this is a link to pre-packaged datasources from the Broad Institute. Any of the tar.gz files will do.
       - `annotsv_annotations_dir_tgz`: [annotsv_311_annotations_dir.tgz] - These annotations are simply those from the install-human-annotation installation process run during AnnotSV installation. Specifically these are the annotations installed with v3.1.1 of the software. Newer or older annotations can be slotted in here as needed.
@@ -500,8 +501,8 @@ inputs:
   disable_hotspot_annotation: {type: 'boolean?', doc: "Disable Hotspot Annotation\
       \ and skip this task.", default: false}
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
-  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}] }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv} }
 
   # WGS only Fields
   wgs_calling_interval_list: {type: 'File?', doc: "GATK intervals list-style, or bed\

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -1105,5 +1105,5 @@ hints:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v4.3.3'
+- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v4.3.4'
   label: github-release

--- a/workflow/kfdrc_annot_vcf_wf.cwl
+++ b/workflow/kfdrc_annot_vcf_wf.cwl
@@ -164,8 +164,8 @@ inputs:
       \ to retain as extra columns in MAF"}
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
   custom_enst: {type: 'File?', doc: "Use a file with ens tx IDs for each gene to override\
-      \ VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}]}
+      \ VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}}
 outputs:
   annotated_protected: {type: 'File[]', outputSource: rename_protected/renamed_files}
   annotated_public: {type: 'File[]', outputSource: rename_public/renamed_files}

--- a/workflow/kfdrc_consensus_calling.cwl
+++ b/workflow/kfdrc_consensus_calling.cwl
@@ -153,6 +153,8 @@ inputs:
   disable_hotspot_annotation: {type: 'boolean?', doc: "Disable Hotspot Annotation\
       \ and skip this task.", default: true}
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}] }
 
 outputs:
   annotated_protected_outputs: {type: 'File[]', outputSource: annotate/annotated_protected}
@@ -216,6 +218,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
       output_basename: output_basename
       tool_name: tool_name
     out: [annotated_protected, annotated_public]

--- a/workflow/kfdrc_consensus_calling.cwl
+++ b/workflow/kfdrc_consensus_calling.cwl
@@ -153,8 +153,8 @@ inputs:
   disable_hotspot_annotation: {type: 'boolean?', doc: "Disable Hotspot Annotation\
       \ and skip this task.", default: true}
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
-  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}] }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv} }
 
 outputs:
   annotated_protected_outputs: {type: 'File[]', outputSource: annotate/annotated_protected}

--- a/workflow/kfdrc_production_controlfreec_wf.cwl
+++ b/workflow/kfdrc_production_controlfreec_wf.cwl
@@ -41,7 +41,7 @@ inputs:
   mate_copynumber_file_control: {type: 'File?', doc: "Normal cpn file from previous run. If used, will override bam use"}
   mate_copynumber_file_sample: {type: 'File?', doc: "Tumor cpn file from previous run. If used, will override bam use"}
   gem_mappability_file: {type: 'File?', doc: "GEM mappability file to make read count adjustments with"}
-  min_subclone_presence: {type: 'int?', doc: "Use if you want to detect sublones. Recommend 30 for WGS, 30 for WXS"}
+  min_subclone_presence: {type: 'int?', doc: "Use if you want to detect sublones. Recommend 20 for WGS, 30 for WXS"}
   cfree_chr_len: { type: File, doc: "file with chromosome lengths" }
   cfree_ploidy: { type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try" }
   output_basename: { type: string, doc: "String value to use as basename for outputs" }

--- a/workflow/kfdrc_production_controlfreec_wf.cwl
+++ b/workflow/kfdrc_production_controlfreec_wf.cwl
@@ -41,7 +41,7 @@ inputs:
   mate_copynumber_file_control: {type: 'File?', doc: "Normal cpn file from previous run. If used, will override bam use"}
   mate_copynumber_file_sample: {type: 'File?', doc: "Tumor cpn file from previous run. If used, will override bam use"}
   gem_mappability_file: {type: 'File?', doc: "GEM mappability file to make read count adjustments with"}
-  min_subclone_presence: {type: 'float?', doc: "Use if you want to detect sublones. Recommend 0.2 for WGS, 0.3 for WXS"}
+  min_subclone_presence: {type: 'int?', doc: "Use if you want to detect sublones. Recommend 30 for WGS, 30 for WXS"}
   cfree_chr_len: { type: File, doc: "file with chromosome lengths" }
   cfree_ploidy: { type: 'int[]', doc: "Array of ploidy possibilities for ControlFreeC to try" }
   output_basename: { type: string, doc: "String value to use as basename for outputs" }

--- a/workflow/kfdrc_production_lancet_wf.cwl
+++ b/workflow/kfdrc_production_lancet_wf.cwl
@@ -99,6 +99,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}] }
 
 
 outputs:
@@ -238,6 +240,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out:
       [lancet_prepass_vcf, lancet_protected_outputs, lancet_public_outputs]
 

--- a/workflow/kfdrc_production_lancet_wf.cwl
+++ b/workflow/kfdrc_production_lancet_wf.cwl
@@ -99,8 +99,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
-  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}] }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv} }
 
 
 outputs:

--- a/workflow/kfdrc_production_mutect2_wf.cwl
+++ b/workflow/kfdrc_production_mutect2_wf.cwl
@@ -101,8 +101,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"gnomad_3_1_1_AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
-  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}] }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv} }
 
 outputs:
   mutect2_prepass_vcf: { type: 'File', outputSource: run_mutect2/mutect2_filtered_vcf }

--- a/workflow/kfdrc_production_mutect2_wf.cwl
+++ b/workflow/kfdrc_production_mutect2_wf.cwl
@@ -101,6 +101,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"gnomad_3_1_1_AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}] }
 
 outputs:
   mutect2_prepass_vcf: { type: 'File', outputSource: run_mutect2/mutect2_filtered_vcf }
@@ -210,6 +212,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out:
       [mutect2_filtered_stats, mutect2_filtered_vcf, mutect2_protected_outputs, mutect2_public_outputs]
 

--- a/workflow/kfdrc_production_strelka2_wf.cwl
+++ b/workflow/kfdrc_production_strelka2_wf.cwl
@@ -87,8 +87,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"gnomad_3_1_1_AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
-  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}] }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv} }
 
 
 outputs:

--- a/workflow/kfdrc_production_strelka2_wf.cwl
+++ b/workflow/kfdrc_production_strelka2_wf.cwl
@@ -87,6 +87,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"gnomad_3_1_1_AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}] }
 
 
 outputs:
@@ -166,6 +168,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out:
       [strelka2_prepass_vcf, strelka2_protected_outputs, strelka2_public_outputs]
 

--- a/workflow/kfdrc_production_vardict_wf.cwl
+++ b/workflow/kfdrc_production_vardict_wf.cwl
@@ -94,6 +94,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv}] }
 
 outputs:
   vardict_prepass_vcf: { type: 'File', outputSource: run_vardict/vardict_prepass_vcf }
@@ -217,6 +219,7 @@ steps:
       protein_snv_hotspots: protein_snv_hotspots
       protein_indel_hotspots: protein_indel_hotspots
       maf_center: maf_center
+      custom_enst: custom_enst
     out:
       [vardict_prepass_vcf, vardict_protected_outputs, vardict_public_outputs]
 

--- a/workflow/kfdrc_production_vardict_wf.cwl
+++ b/workflow/kfdrc_production_vardict_wf.cwl
@@ -94,8 +94,8 @@ inputs:
   gatk_filter_expression: {type: 'string[]', doc: "Array of filter expressions to establish criteria to tag variants with. See https://gatk.broadinstitute.org/hc/en-us/articles/360036730071-VariantFiltration, recommend: \"vc.getGenotype('\" + inputs.input_normal_name + \"').getDP() <= 7\"), \"AF > 0.001\"]"}
   disable_hotspot_annotation: { type: 'boolean?', doc: "Disable Hotspot Annotation and skip this task.", default: false }
   maf_center: {type: 'string?', doc: "Sequencing center of variant called", default: "."}
-  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": [{class: File, path: 6480c8a61dfc710d24a3a368,
-        name: kf_isoform_override.tsv}] }
+  custom_enst: { type: 'File?', doc: "Use a file with ens tx IDs for each gene to override VEP PICK", "sbg:suggestedValue": {class: File, path: 6480c8a61dfc710d24a3a368,
+        name: kf_isoform_override.tsv} }
 
 outputs:
   vardict_prepass_vcf: { type: 'File', outputSource: run_vardict/vardict_prepass_vcf }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR wraps up the HotSpot revolution.
 - Added a disable VEP flag to annot wf, if VEP input is fine but downstream is to be repeated
 - Added a custom transcript port and default input for preferred canonical isforms
 - Updated documentation in annot wf about new features
 - Bonus bug fix found running cwl tool of a type mismatch in controlfreec. We've never really used that input so no harm there
 - Comments got removed running pub app script. Not sure how I feel about that...

Fixes # https://github.com/d3b-center/bixu-tracker/issues/1903

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran task on affected input: https://cavatica.sbgenomics.com/u/zhangb1/opentagret-4-callers-vcf-temp-holder/files/648750ef68697e6f54b4ce74/
- [ ] Generic whole pipeline run: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/e4e0dcf8-7493-4639-8261-26569c278b90

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
