### PR TITLE
🐛  bump filtermutectcalls docker

### DIFF
--- a/tools/gatk_filtermutectcalls.cwl
+++ b/tools/gatk_filtermutectcalls.cwl
@@ -6,15 +6,16 @@ requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: DockerRequirement
-    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.1.0'
+    dockerPull: 'broadinstitute/gatk:4.2.0.0'
   - class: ResourceRequirement
     ramMin: ${ return inputs.max_memory * 1000 }
     coresMin: 2
-baseCommand: [/gatk, FilterMutectCalls]
+baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
+      gatk FilterMutectCalls
       --java-options "-Xmx${return Math.floor(inputs.max_memory*1000/1.074-1)}m"
       -V $(inputs.mutect_vcf.path)
       -O $(inputs.output_basename).mutect2_filtered.vcf.gz

--- a/workflow/kfdrc-somatic-variant-workflow.cwl
+++ b/workflow/kfdrc-somatic-variant-workflow.cwl
@@ -998,5 +998,5 @@ hints:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v4.4.0'
+- id: 'https://github.com/kids-first/kf-somatic-workflow/releases/tag/v4.4.1'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

OPs came a across a bug in FilterMutectCalls: https://cavatica.sbgenomics.com/u/d3b-bixu-ops/sd-be4gmfqa-somatic-mutations-target-tumor/tasks/74abbcd0-99d2-4e02-8096-b1cf494235ed/

This is a known bug that was solved in GATK 4.1.5.0: https://gatk.broadinstitute.org/hc/en-us/community/posts/360057968772-FilterMutectCalls-Error-java-lang-IllegalArgumentException-log10-p-Values-must-be-non-infinite-and-non-NAN

So we're just bumping the version of that tool to 4.2.0.0

Part of https://github.com/d3b-center/bixu-tracker/issues/2135

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/d3b-bixu-ops/sd-be4gmfqa-somatic-mutations-target-tumor/tasks/c78357f0-f26f-4389-b135-7d3911f9a861/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
