### PR TITLE
🔧  do not rename reheadered vcfs

### DIFF
--- a/sub_workflows/kfdrc_lancet_sub_wf.cwl
+++ b/sub_workflows/kfdrc_lancet_sub_wf.cwl
@@ -94,7 +94,7 @@ steps:
       input_vcf: sort_merge_lancet_vcf/merged_vcf
       output_filename:
         valueFrom: |
-          $(inputs.input_vcf.basename.replace(".vcf", ".reheadered.vcf"))
+          $(inputs.input_vcf.basename)
       new_normal_name: input_normal_name
       new_tumor_name: input_tumor_name
       old_normal_name: old_normal_name

--- a/sub_workflows/kfdrc_manta_sub_wf.cwl
+++ b/sub_workflows/kfdrc_manta_sub_wf.cwl
@@ -57,7 +57,7 @@ steps:
       input_vcf: manta/output_sv
       output_filename:
         valueFrom: |
-          $(inputs.input_vcf.basename.replace(".vcf", ".reheadered.vcf"))
+          $(inputs.input_vcf.basename)
       new_normal_name: input_normal_name
       new_tumor_name: input_tumor_name
       old_normal_name: old_normal_name

--- a/sub_workflows/kfdrc_mutect2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_mutect2_sub_wf.cwl
@@ -139,7 +139,7 @@ steps:
       input_vcf: filter_mutect2_vcf/filtered_vcf
       output_filename:
         valueFrom: |
-          $(inputs.input_vcf.basename.replace(".vcf", ".reheadered.vcf"))
+          $(inputs.input_vcf.basename)
       new_normal_name: input_normal_name
       new_tumor_name: input_tumor_name
       old_normal_name: old_normal_name

--- a/sub_workflows/kfdrc_strelka2_sub_wf.cwl
+++ b/sub_workflows/kfdrc_strelka2_sub_wf.cwl
@@ -95,7 +95,7 @@ steps:
       input_vcf: merge_strelka2_vcf/merged_vcf
       output_filename:
         valueFrom: |
-          $(inputs.input_vcf.basename.replace(".vcf", ".reheadered.vcf"))
+          $(inputs.input_vcf.basename)
       new_normal_name: input_normal_name
       new_tumor_name: input_tumor_name
       old_normal_name:

--- a/sub_workflows/kfdrc_vardict_sub_wf.cwl
+++ b/sub_workflows/kfdrc_vardict_sub_wf.cwl
@@ -101,7 +101,7 @@ steps:
       input_vcf: sort_merge_vardict_vcf/merged_vcf
       output_filename:
         valueFrom: |
-          $(inputs.input_vcf.basename.replace(".vcf", ".reheadered.vcf"))
+          $(inputs.input_vcf.basename)
       new_normal_name: input_normal_name
       new_tumor_name: input_tumor_name
       old_normal_name: old_normal_name


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

We want to keep consistent naming for the prepass VCF when we perform reheader.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have committed any related changes to the PR
